### PR TITLE
Fix error deprecated: function split() is deprecated

### DIFF
--- a/adodb/drivers/adodb-postgres64.inc.php
+++ b/adodb/drivers/adodb-postgres64.inc.php
@@ -659,7 +659,7 @@ WHERE (c2.relname=\'%s\' or c2.relname=lower(\'%s\'))';
 			if (strlen($db) == 0) $db = 'template1';
 			$db = adodb_addslashes($db);
 		   	if ($str)  {
-			 	$host = split(":", $str);
+			 	$host = explode(":", $str);
 				if ($host[0]) $str = "host=".adodb_addslashes($host[0]);
 				else $str = '';
 				if (isset($host[1])) $str .= " port=$host[1]";


### PR DESCRIPTION
Deprecated: Function split() is deprecated in /home/web/issues/public/adodb/drivers/adodb-postgres64.inc.php on line 662
