### PR TITLE
Fix absoluteURI function to enable port redirection through NAT

### DIFF
--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -218,6 +218,10 @@ class Flyspray
         $host = 'localhost';
         if (!empty($_SERVER['HTTP_HOST'])) {
             list($host) = explode(':', $_SERVER['HTTP_HOST']);
+
+            if (strpos($_SERVER['HTTP_HOST'], ':') !== false && !isset($port)) {
+                $port = explode(':', $_SERVER['HTTP_HOST'])[1];
+            }
         } elseif (!empty($_SERVER['SERVER_NAME'])) {
             list($host) = explode(':', $_SERVER['SERVER_NAME']);
         }


### PR DESCRIPTION
Flyspray implementation won't work when webserver is behind NAT and listens on standard ports. AbsoluteURI() assume that when no port is specified, correct port is the one which webserver is bound to (eg. 80, 443). It doesn't work if NAT translation is set like this: 8080 -> 80. It redirects to http://foo/flyspray instead of http://foo:8080/flyspray which is correct.
