### PR TITLE
Send email notifications as HTML

### DIFF
--- a/includes/class.notify.php
+++ b/includes/class.notify.php
@@ -285,7 +285,7 @@ class Notifications {
             $log->setLogLevel(SWIFT_LOG_EVERYTHING); 
         }
 
-        // Make plaitext URLs into hyperlinks, but don't disturb existing ones!
+        // Make plaintext URLs into hyperlinks, but don't disturb existing ones!
         $body = preg_replace("/(?<!\")(https?:\/\/)([a-zA-Z0-9\-.]+\.[a-zA-Z0-9\-]+([\/]([a-zA-Z0-9_\/\-.?&%=+#])*)*)/", '<a href="$1$2">$2</a>', $body);
 
         // Make newlines into HTML line breaks


### PR DESCRIPTION
Since task details & comments often contain HTML, it is much more useful if the email notifications render fully.  This is done with 3 changes:
1) Set the content type to text/html
2) Preserve formatting of non-HTML portions (e.g. heading, disclaimer, etc.) by converting newlines into HTML line breaks
3) Upconvert plaintext URLs into hyperlinks (useful mainly for links back to Flyspray)
