### PR TITLE
Export task list as a .csv

### DIFF
--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -225,7 +225,15 @@
 
             </div>
             <input type="hidden" name="do" value="index"/>
+
+ <!--- Added 2/1/2014 LAE --!>
+
+ <form action="{$baseurl}/scripts/index.php" method="post">
+  &nbsp;&nbsp;&nbsp&nbsp<input type='submit' name='export_list' value='Export Tasklist'>
+ </form>
+
 </div>
+
 </form>
 </map>
 </div>


### PR DESCRIPTION
Added functionality to export the task list as .csv. The code retains the ordering of the tasks as they are listed in the browser window. I also found it mush more useful to list a lot more tasks per page than the default. Hope someone finds this useful.
