### PR TITLE
Fix project name in dependent/subtasks.

### DIFF
--- a/scripts/details.php
+++ b/scripts/details.php
@@ -72,10 +72,11 @@ else {
     }
 
     // Sub-Tasks
-    $subtasks = $db->Query('SELECT  task_id 
-                                 FROM  {tasks} 
-                                WHERE  supertask_id = ?
-                                ORDER BY list_order', 
+    $subtasks = $db->Query('SELECT  t.task_id, p.project_title 
+                                 FROM  {tasks} t
+			    LEFT JOIN  {projects} p ON t.project_id = p.project_id
+                                WHERE  t.supertask_id = ?
+                                ORDER BY t.list_order', 
                                 array($task_id));
     
     // Parent categories
@@ -86,11 +87,12 @@ else {
                         array($task_details['lft'], $task_details['rgt'], $task_details['cproj']));
 
     // Check for task dependencies that block closing this task
-    $check_deps   = $db->Query('SELECT  t.*, s.status_name, r.resolution_name, d.depend_id
+    $check_deps   = $db->Query('SELECT  t.*, s.status_name, r.resolution_name, d.depend_id, p.project_title
                                   FROM  {dependencies} d
                              LEFT JOIN  {tasks} t on d.dep_task_id = t.task_id
                              LEFT JOIN  {list_status} s ON t.item_status = s.status_id
                              LEFT JOIN  {list_resolution} r ON t.resolution_reason = r.resolution_id
+			     LEFT JOIN  {projects} p ON t.project_id = p.project_id
                                  WHERE  d.task_id = ?', array($task_id));
 
     // Check for tasks that this task blocks

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -718,7 +718,7 @@ function quick_edit(elem, id)
             <?php foreach ($deps as $dependency): ?>
             <tr>
                 <td><?php echo $dependency['task_id'] ?></td>
-                <td><?php echo $projects[$dependency['project_id']-1]['project_title'] ?></td>
+                <td><?php echo $dependency['project_title'] ?></td>
                 <td><?php echo tpl_tasklink($dependency['task_id']); ?></td>
                 <td><?php echo $fs->priorities[$dependency['task_priority']] ?></td>
                 <td class="severity<?php echo Filters::noXSS($dependency['task_severity']); ?>"><?php echo $fs->
@@ -772,7 +772,7 @@ function quick_edit(elem, id)
             <?php $subtask = $fs->GetTaskDetails($subtaskOrgin['task_id']); ?>
             <tr id="task<?php echo $subtask['task_id']; ?>" class="severity<?php echo Filters::noXSS($subtask['task_severity']); ?>">
                 <td><?php echo $subtask['task_id'] ?></td>
-                <td><?php echo $projects[$subtask['project_id']-1]['project_title'] ?></td>
+                <td><?php echo $subtask['project_title'] ?></td>
                 <td><?php echo tpl_tasklink($subtask['task_id']); ?></td>
                 <td><?php echo $fs->priorities[$subtask['task_priority']] ?></td>
                 <td class="severity<?php echo Filters::noXSS($subtask['task_severity']); ?>"><?php echo $fs->severities[$subtask['task_severity']]


### PR DESCRIPTION
Fixes non-existing index when showing the project name of a dependent or subtask. The original submitter of this feature seems to have misunderstood how $projects array is indexed. There could be alternative solutions to the problem, but I didn't see them immediately. Modifying the SQL-queries and having the necessary information available in $dependency and $subtask seems both safe and working solution.