### PR TITLE
Add aggregate functions to 2 SQL-queries.

### DIFF
--- a/includes/class.project.php
+++ b/includes/class.project.php
@@ -351,7 +351,7 @@ class Project
 		//NOTE: from_unixtime() on mysql, to_timestamp() on PostreSQL
         $func = ('mysql' == $db->dblink->dataProvider) ? 'from_unixtime' : 'to_timestamp';
         
-		$result = $db->Query("SELECT count(date({$func}(event_date))) as val, event_date
+		$result = $db->Query("SELECT count(date({$func}(event_date))) as val, min(event_date) as event_date
 							  FROM {history} h left join {tasks} t on t.task_id = h.task_id 
 							  WHERE t.project_id = ? 
 							  AND date({$func}(event_date)) BETWEEN date(?) and date(?)

--- a/includes/class.project.php
+++ b/includes/class.project.php
@@ -351,7 +351,7 @@ class Project
 		//NOTE: from_unixtime() on mysql, to_timestamp() on PostreSQL
         $func = ('mysql' == $db->dblink->dataProvider) ? 'from_unixtime' : 'to_timestamp';
         
-		$result = $db->Query("SELECT count(date({$func}(event_date))) as val, min(event_date) as event_date
+		$result = $db->Query("SELECT count(date({$func}(event_date))) as val, MIN(event_date) as event_date
 							  FROM {history} h left join {tasks} t on t.task_id = h.task_id 
 							  WHERE t.project_id = ? 
 							  AND date({$func}(event_date)) BETWEEN date(?) and date(?)

--- a/includes/class.user.php
+++ b/includes/class.user.php
@@ -353,7 +353,7 @@ class User
 		//NOTE: from_unixtime() on mysql, to_timestamp() on PostreSQL
         $func = ('mysql' == $db->dblink->dataProvider) ? 'from_unixtime' : 'to_timestamp';
         
-        $result = $db->Query("SELECT count(date({$func}(event_date))) as val, min(event_date) as event_date
+        $result = $db->Query("SELECT count(date({$func}(event_date))) as val, MIN(event_date) as event_date
 							  FROM {history} h left join {tasks} t on t.task_id = h.task_id 
 							  WHERE t.project_id = ? AND h.user_id = ?
                               AND date({$func}(event_date)) BETWEEN date(?) and date(?)

--- a/includes/class.user.php
+++ b/includes/class.user.php
@@ -353,7 +353,7 @@ class User
 		//NOTE: from_unixtime() on mysql, to_timestamp() on PostreSQL
         $func = ('mysql' == $db->dblink->dataProvider) ? 'from_unixtime' : 'to_timestamp';
         
-        $result = $db->Query("SELECT count(date({$func}(event_date))) as val, event_date
+        $result = $db->Query("SELECT count(date({$func}(event_date))) as val, min(event_date) as event_date
 							  FROM {history} h left join {tasks} t on t.task_id = h.task_id 
 							  WHERE t.project_id = ? AND h.user_id = ?
                               AND date({$func}(event_date)) BETWEEN date(?) and date(?)


### PR DESCRIPTION
MySQL doesn't require these, PostgreSQL really does, but they should neither harm MySQL (please test!). It's unknown to me which one of the available event_dates MySQL chooses when it's not explicitly specified, using MIN() seemed safe, because it actually doesn't seem to matter as long as event_date falls on the right date.