### PR TITLE
the anti csrf and less cookies merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 www.flyspray.org
 
-Flyspray Bug Tracking System
+# Flyspray Bug Tracking System
 
-Flyspray is an uncomplicated, web-based bug tracking system for assisting with software development. Learn more...
+Flyspray is an uncomplicated, web-based bug tracking system.
 If you already know all about Flyspray, why wait? Download it now!
 If Flyspray is helping your business, please consider helping us by donating a couple of dollars. 
 Be added to our generous donators page today!
@@ -13,22 +13,22 @@ Have you spotted Flyspray in the wild? Does your company or project use Flyspray
 You can send a note to the Mailing List including your project or company name, Flyspray URL (if public), 
 homepage, and a nice testimonial if you are in the mood and we'll have it added to the list of who is Using Flyspray!
 
-Installation:
+## Installation
 http://flyspray.org/manual:installation
 
-Upgrading:
-Create a backup of your files and database
-Remove all files except the attachments directory and flyspray.conf.php
-Copy the new files to the Flyspray directory
-make sure flyspray.conf.php is writeable by the webserver.
-Run the upgrader at http://yourflyspray/setup/upgrade.php
+## Upgrading
+Create a backup of your files and database  
+Remove all files except the attachments directory and flyspray.conf.php  
+Copy the new files to the Flyspray directory  
+Make sure flyspray.conf.php is writeable by the webserver.  
+Run the upgrader at http://yourflyspray/setup/upgrade.php  
 
 
-Dependencies:
+## Dependencies
 
-# Install php
+### Install php
 sudo apt-get install php
 
-# Install composer
-curl -sS https://getcomposer.org/installer | php
-php composer.phar install
+### Install composer
+curl -sS https://getcomposer.org/installer | php  
+php composer.phar install  

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ homepage, and a nice testimonial if you are in the mood and we'll have it added 
 http://flyspray.org/manual:installation
 
 ## Upgrading
-Create a backup of your files and database  
-Remove all files except the attachments directory and flyspray.conf.php  
-Copy the new files to the Flyspray directory  
-Make sure flyspray.conf.php is writeable by the webserver.  
-Run the upgrader at http://yourflyspray/setup/upgrade.php  
-
+1. Create a backup of your files and database  
+2. Remove all files _except the attachments directory, avatars directory and flyspray.conf.php_  
+3. Copy the new files to the Flyspray directory
+4. Make sure flyspray.conf.php is writeable by the webserver.
+5. TODO Composer stuff???
+5. Run the upgrader at http://yourflyspray/setup/upgrade.php  
 
 ## Dependencies
 
 ### Install php
-sudo apt-get install php
+    sudo apt-get install php
 
 ### Install composer
-curl -sS https://getcomposer.org/installer | php  
-php composer.phar install  
+    curl -sS https://getcomposer.org/installer | php  
+    php composer.phar install  

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ www.flyspray.org
 
 # Flyspray Bug Tracking System
 
-Flyspray is an uncomplicated, web-based bug tracking system.
+Flyspray is an uncomplicated, web-based bug and task tracking system.
+
 If you already know all about Flyspray, why wait? Download it now!
+
 If Flyspray is helping your business, please consider helping us by donating a couple of dollars. 
 Be added to our generous donators page today!
 
-Have you spotted Flyspray in the wild? Does your company or project use Flyspray? 
+Have you spotted Flyspray in the wild? Does your company or project use Flyspray?  
 You can send a note to the Mailing List including your project or company name, Flyspray URL (if public), 
 homepage, and a nice testimonial if you are in the mood and we'll have it added to the list of who is Using Flyspray!
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ http://flyspray.org/manual:installation
 
 ## Upgrading
 1. Create a backup of your files and database  
-2. Remove all files _except the attachments directory, avatars directory and flyspray.conf.php_  
+2. Remove all files **except the attachments directory, avatars directory and flyspray.conf.php**  
 3. Copy the new files to the Flyspray directory
 4. Make sure flyspray.conf.php is writeable by the webserver.
 5. TODO Composer stuff???

--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -714,27 +714,42 @@ class Flyspray
     // Set cookie {{{
     /**
      * Sets a cookie, automatically setting the URL
+     * Now same params as PHP's builtin setcookie()
      * @param string $name
      * @param string $val
      * @param integer $time
+     * @param string $path
+     * @param string $domain
+     * @param bool $secure
+     * @param bool $httponly
      * @access public static
      * @return bool
-     * @version 1.0
+     * @version 1.1
      */
-    public static function setCookie($name, $val, $time = null)
+    public static function setCookie($name, $val, $time = null, $path=null, $domain=null, $secure=false, $httponly=false)
     {
-        $url = parse_url($GLOBALS['baseurl']);
+        if (null===$path){
+            $url = parse_url($GLOBALS['baseurl']);
+        }else{
+            $url['path']=$path;
+        }
+
         if (!is_int($time)) {
             $time = time()+60*60*24*30;
         }
-
+        if(null===$domain){
+            $domain='';
+        }
+        if(null===$secure){
+            $secure=false;
+        }
         if((strlen($name) + strlen($val)) > 4096) {
             //violation of the protocol
             trigger_error("Flyspray sent a too big cookie, browsers will not handle it");
             return false;
         }
 
-        return setcookie($name, $val, $time, $url['path']);
+        return setcookie($name, $val, $time, $url['path'],$domain,$secure,$httponly);
     } // }}}
             // Start the session {{{
     /**

--- a/includes/class.tpl.php
+++ b/includes/class.tpl.php
@@ -154,7 +154,7 @@ function tpl_form($action, $name=false, $method='post', $enctype='multipart/form
         global $baseurl;
 
         if(substr($action,0,4)!='http'){$action=$baseurl.$action;}
-        return '<form action="'.$action.'"'.($method=='get'?' method="get"':'').
+        return '<form action="'.$action.'"'.($method=='get'?' method="get"':'method="post"').
                 ( $name!='' ? ' name="'.$name.'"':'').    
                 ( ' enctype="'.$enctype.'"').
                 ( ' '.$attr).'>'.

--- a/includes/class.tpl.php
+++ b/includes/class.tpl.php
@@ -149,16 +149,16 @@ class FSTpl extends Tpl
 
 }
 # draws the form start tag and the important anticsrftoken on 'post'-forms
-function tpl_form($action, $name=false, $method='post', $enctype='multipart/form-data', $attr=array())
+function tpl_form($action, $name=false, $method='post', $enctype='multipart/form-data', $attr='')
 {
         global $baseurl;
 
         if(substr($action,0,4)!='http'){$action=$baseurl.$action;}
         return '<form action="'.$action.'"'.($method=='get'?' method="get"':'').
-                ( $name!='' ? ' name="'.$name.'"':'').'>'.
-                ( $method=='post' ? '<input type="hidden" name="csrftoken" value="'.$_SESSION['csrftoken'].'"':'').
+                ( $name!='' ? ' name="'.$name.'"':'').    
                 ( ' enctype="'.$enctype.'"').
-                '>';
+                ( ' '.$attr).'>'.
+                ( $method=='post' ? '<input type="hidden" name="csrftoken" value="'.$_SESSION['csrftoken'].'">':'');
 }
 
 // {{{ costful templating functions, TODO: optimize them

--- a/includes/class.tpl.php
+++ b/includes/class.tpl.php
@@ -154,7 +154,7 @@ function tpl_form($action, $name=false, $method='post', $enctype='multipart/form
         global $baseurl;
 
         if(substr($action,0,4)!='http'){$action=$baseurl.$action;}
-        return '<form action="'.$action.'"'.($method=='get'?' method="get"':'method="post"').
+        return '<form action="'.$action.'"'.($method=='get'?' method="get"':' method="post"').
                 ( $name!='' ? ' name="'.$name.'"':'').    
                 ( ' enctype="'.$enctype.'"').
                 ( ' '.$attr).'>'.

--- a/includes/class.tpl.php
+++ b/includes/class.tpl.php
@@ -149,9 +149,15 @@ class FSTpl extends Tpl
 
 }
 # draws the form start tag and the important anticsrftoken on 'post'-forms
-function tpl_form($action, $name=false, $method='post', $enctype='multipart/form-data', $attr='')
+function tpl_form($action, $name=null, $method=null, $enctype=null, $attr='')
 {
         global $baseurl;
+        if (null === $method) {
+                $method='post';
+        }
+        if (null === $enctype) {
+                $enctype='multipart/form-data';
+        }
 
         if(substr($action,0,4)!='http'){$action=$baseurl.$action;}
         return '<form action="'.$action.'"'.($method=='get'?' method="get"':' method="post"').

--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -1067,8 +1067,8 @@ switch ($action = Req::val('action'))
 
                     // If the user is changing their password, better update their cookie hash
                     if ($user->id == Post::val('user_id')) {
-                        Flyspray::setcookie('flyspray_passhash',
-                                crypt($new_hash, $conf['general']['cookiesalt']), time()+3600*24*30);
+                        Flyspray::setCookie('flyspray_passhash',
+                                crypt($new_hash, $conf['general']['cookiesalt']), time()+3600*24*30,null,null,null,true);
                     }
                 }
                 $jabId = Post::val('jabber_id');

--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -1603,7 +1603,7 @@ switch ($action = Req::val('action'))
 
         if ($db->AffectedRows()) {
             Flyspray::logEvent($task['task_id'], 6, $comment['user_id'],
-                    $comment['comment_text'], $comment['date_added']);
+                    $comment['comment_text'], '', $comment['date_added']);
         }
 
         while ($attachment = $db->FetchRow($check_attachments)) {

--- a/index.php
+++ b/index.php
@@ -168,7 +168,15 @@ $page->pushTpl('header.tpl');
 
 // DB modifications?
 if (Req::has('action')) {
-    require_once(BASEDIR . '/includes/modify.inc.php');
+    # enforcing if the form sent the correct anti csrf token
+    # only allow token by post
+    if( !Post::has('csrftoken') ){
+        die('missingtoken');
+    }elseif( Post::val('csrftoken')==$_SESSION['csrftoken']){
+        require_once(BASEDIR . '/includes/modify.inc.php');
+    }else{   
+        die('wrongtoken');
+    }
 }
 
 if (!defined('NO_DO')) {

--- a/scripts/authenticate.php
+++ b/scripts/authenticate.php
@@ -56,8 +56,8 @@ if (Req::val('user_name') != '' && Req::val('password') != '') {
 
         // Set a couple of cookies
         $passweirded = crypt($user->infos['user_pass'], $conf['general']['cookiesalt']);
-        Flyspray::setcookie('flyspray_userid', $user->id, $cookie_time);
-        Flyspray::setcookie('flyspray_passhash', $passweirded, $cookie_time);
+        Flyspray::setCookie('flyspray_userid', $user->id, $cookie_time,null,null,null,true);
+        Flyspray::setCookie('flyspray_passhash', $passweirded, $cookie_time,null,null,null,true);
         // If the user had previously requested a password change, remove the magic url
         $remove_magic = $db->Query("UPDATE {users} SET magic_url = '' WHERE user_id = ?",
                                     array($user->id));

--- a/scripts/depends.php
+++ b/scripts/depends.php
@@ -182,3 +182,4 @@ $page->assign('task_id', $id);
 
 $page->setTitle(sprintf('FS#%d : %s', $id, L('dependencygraph')));
 $page->pushTpl('depends.tpl');
+?>

--- a/scripts/index.php
+++ b/scripts/index.php
@@ -250,7 +250,7 @@ function do_cmp($a, $b)
 */
 function export_task_list()
 {
-        global $tasks, $fs, $sort, $orderby;
+        global $tasks, $fs, $user, $sort, $orderby;
 
         if (!is_array($tasks)){
                 return;

--- a/scripts/index.php
+++ b/scripts/index.php
@@ -283,16 +283,12 @@ function export_task_list()
             'os'         => 'os_name',
             'private'    => 'mark_private',
             'supertask'  => 'supertask_id',
-                'detailed_desc'=>'detailed_desc',
+            'detailed_desc'=>'detailed_desc',
         );
 
 
         # we can put this info also in the filename ...
         #$projectinfo = array('Project ', $tasks[0]['project_title'], date("H:i:s d-m-Y") );
-
-        $headings= array('ID','Category','Task Type','Severity','Summary','Status','Progress');
-        # TODO maybe if user just want localized headings for nonenglish speaking audience..
-        #$headings= array('ID','Category','Task Type','Severity','Summary','Status','Progress');
 
         // sort the tasks into the order selected by the user. Set
         // global vars for use by sort comparison function
@@ -320,6 +316,20 @@ function export_task_list()
 
         $output = fopen('php://output', 'w');
         #fputcsv($output, $projectinfo);
+        $headings= array(
+        	'ID',
+        	'Category',
+        	'Task Type',
+        	'Severity',
+        	'Summary',
+        	'Status',
+        	'Progress',
+        	$user->perms('view_effort') ?'Estimated Effort':'',
+        	$user->perms('view_actual_effort') ?'Done Effort':'',
+        	'Description',
+        );
+        # TODO maybe if user just want localized headings for nonenglish speaking audience..
+        #$headings= array('ID','Category','Task Type','Severity','Summary','Status','Progress');
         fputcsv($output, $headings);
         foreach ($tasks as $task) {
                 $row = array(
@@ -329,7 +339,14 @@ function export_task_list()
                         $fs->severities[ $task['task_severity'] ],
                         $task['item_summary'],
                         $task['status_name'],
-                        $task['percent_complete']
+                        $task['percent_complete'],
+                        # better permission namings
+                        #$user->perms('view_estimated_effort')? $task['estimated_effort']:'',
+                        #$user->perms('view_done_effort')? $task['effort']:'',
+                        # current permission naming
+                        $user->perms('view_effort') ? $task['estimated_effort']:'',
+                        $user->perms('view_actual_effort') ? $task['effort']:'',
+                        $task['detailed_desc']
                 );
                 fputcsv($output, $row);
         }

--- a/scripts/oauth.php
+++ b/scripts/oauth.php
@@ -144,3 +144,4 @@ $return_to = $_SESSION['return_to'];
 unset($_SESSION['return_to']);
 
 Flyspray::Redirect($return_to);
+?>

--- a/scripts/oauth.php
+++ b/scripts/oauth.php
@@ -136,8 +136,8 @@ $user = new User($user_id);
 
 // Set a couple of cookies
 $passweirded = crypt($user->infos['user_pass'], $conf['general']['cookiesalt']);
-Flyspray::setcookie('flyspray_userid', $user->id, 0);
-Flyspray::setcookie('flyspray_passhash', $passweirded, 0);
+Flyspray::setCookie('flyspray_userid', $user->id, 0,null,null,null,true);
+Flyspray::setCookie('flyspray_passhash', $passweirded, 0,null,null,null,true);
 $_SESSION['SUCCESS'] = L('loginsuccessful');
 
 $return_to = $_SESSION['return_to'];

--- a/themes/CleanFS/templates/admin.newproject.tpl
+++ b/themes/CleanFS/templates/admin.newproject.tpl
@@ -1,6 +1,6 @@
 <div id="toolbox">
   <h3><?php echo Filters::noXSS(L('createnewproject')); ?></h3>
-  <form action="<?php echo Filters::noXSS(CreateURL('admin', 'newproject')); ?>" method="post">
+  <?php echo tpl_form(CreateURL('admin', 'newproject')); ?>
     <div>
       <input type="hidden" name="action" value="admin.newproject" />
       <input type="hidden" name="area" value="newproject" />

--- a/themes/CleanFS/templates/admin.prefs.tpl
+++ b/themes/CleanFS/templates/admin.prefs.tpl
@@ -17,8 +17,7 @@
 
 <div id="toolbox">
   <h3><?php echo Filters::noXSS(L('admintoolboxlong')); ?> :: <?php echo Filters::noXSS(L('preferences')); ?></h3>
-
-  <form action="<?php echo Filters::noXSS(CreateURL('admin', 'prefs')); ?>" method="post" enctype="multipart/form-data">
+  <?php echo tpl_form(CreateURL('admin', 'prefs')); ?>
   <ul id="submenu">
    <li><a href="#general"><?php echo Filters::noXSS(L('general')); ?></a></li>
    <li><a href="#userregistration"><?php echo Filters::noXSS(L('userregistration')); ?></a></li>

--- a/themes/CleanFS/templates/common.cat.tpl
+++ b/themes/CleanFS/templates/common.cat.tpl
@@ -16,7 +16,7 @@ if (count($categories)) : ?>
   </div>
 </div>
 <?php endif; ?>
-  <form action="<?php echo Filters::noXSS(CreateURL($do, 'cat', $proj->id)); ?>" method="post">
+<?php echo tpl_form(Filters::noXSS(CreateURL($do, 'cat', $proj->id))); ?>
     <table class="list" id="catTable">
        <thead>
        <tr>
@@ -81,12 +81,9 @@ if (count($categories)) : ?>
       ?>
     </script>
     <?php endif; ?>
-  </form>
-
-  <hr />
-
-  <!-- Form to add a new category to the list -->
-  <form action="<?php echo Filters::noXSS(CreateURL($do, 'cat', $proj->id)); ?>" method="post">
+</form>
+<hr />
+<?php echo tpl_form(Filters::noXSS(CreateURL($do, 'cat', $proj->id))); ?>
     <table class="list">
       <tr>
         <td>
@@ -112,4 +109,4 @@ if (count($categories)) : ?>
         </td>
       </tr>
     </table>
-  </form>
+</form>

--- a/themes/CleanFS/templates/common.editallusers.tpl
+++ b/themes/CleanFS/templates/common.editallusers.tpl
@@ -1,4 +1,6 @@
-<form action="<?php if ($do == 'admin'): ?><?php echo Filters::noXSS(CreateURL($do, 'editallusers')); ?><?php else: ?><?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?><?php endif; ?>" method="post" id="editallusers">
+<?php if ($do == 'admin'): echo tpl_form(Filters::noXSS(CreateURL($do, 'editallusers')),null,null,null,'id="editallusers"');
+                     else: echo tpl_form(Filters::noXSS($_SERVER['SCRIPT_NAME']),       null,null,null,'id="editallusers"');
+endif; ?>
   <ul class="form_elements">
     <li class="required">
       <?php if ($do == 'admin'): ?>

--- a/themes/CleanFS/templates/common.editgroup.tpl
+++ b/themes/CleanFS/templates/common.editgroup.tpl
@@ -9,7 +9,7 @@
         </div>
     </form>
     <hr />
-  <form action="<?php echo Filters::noXSS(CreateURL('editgroup', Req::num('id'), $do)); ?>" method="post">
+  <?php echo tpl_form(Filters::noXSS(CreateURL('editgroup', Req::num('id'), $do))); ?>
     <table class="box">
       <tr>
         <td>
@@ -158,10 +158,8 @@
       </tr>
     </table>
   </form>
-
   <hr />
-
-  <form action="<?php echo Filters::noXSS(CreateURL('editgroup', Req::num('id'), $do)); ?>" method="post">
+  <?php echo tpl_form(Filters::noXSS(CreateURL('editgroup', Req::num('id'), $do))); ?>
    <div>
     <h3><?php echo Filters::noXSS(L('groupmembers')); ?></h3>
     <table id="manage_users_in_groups" class="userlist">

--- a/themes/CleanFS/templates/common.list.tpl
+++ b/themes/CleanFS/templates/common.list.tpl
@@ -8,7 +8,7 @@
     </div>
 </div>
 <?php endif; ?>
-<form action="<?php echo Filters::noXSS(CreateURL($do, $list_type, $proj->id)); ?>" method="post">
+<?php echo tpl_form(Filters::noXSS(CreateURL($do, $list_type, $proj->id))); ?>
   <table class="list" id="listTable">
    <thead>
      <tr>
@@ -85,7 +85,7 @@
   <?php endif; ?>
 </form>
 <hr />
-<form action="<?php echo Filters::noXSS(CreateURL($do, $list_type, $proj->id)); ?>" method="post">
+<?php echo tpl_form(Filters::noXSS(CreateURL($do, $list_type, $proj->id))); ?>
   <table class="list">
     <tr>
       <td>

--- a/themes/CleanFS/templates/common.newgroup.tpl
+++ b/themes/CleanFS/templates/common.newgroup.tpl
@@ -1,5 +1,4 @@
-<form action="<?php echo Filters::noXSS(CreateUrl($do, 'newgroup', $proj->id)); ?>" method="post" id="newgroup">
-    
+<?php echo tpl_form(Filters::noXSS(CreateUrl($do,'newgroup',$proj->id)),null,null,null,'id="newgroup"'); ?>
     <ul class="form_elements">
       <li class="required">
         <label for="groupname"><?php echo Filters::noXSS(L('groupname')); ?> *</label>

--- a/themes/CleanFS/templates/common.newuser.tpl
+++ b/themes/CleanFS/templates/common.newuser.tpl
@@ -1,4 +1,6 @@
-<form action="<?php if ($do == 'admin'): ?><?php echo Filters::noXSS(CreateURL($do, 'newuser')); ?><?php else: ?><?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?><?php endif; ?>" method="post" enctype="multipart/form-data" id="registernewuser">
+<?php if ($do == 'admin'): echo tpl_form(Filters::noXSS(CreateURL($do, 'newuser')),null,null,null,'id="registernewuser"');
+                     else: echo tpl_form(Filters::noXSS($_SERVER['SCRIPT_NAME']),null,null,null,'id="registernewuser"');
+endif; ?>
 	<ul class="form_elements">
 		<li class="required">
 			<?php if ($do == 'admin'): ?>

--- a/themes/CleanFS/templates/common.newuserbulk.tpl
+++ b/themes/CleanFS/templates/common.newuserbulk.tpl
@@ -1,4 +1,6 @@
-<form action="<?php if ($do == 'admin'): ?><?php echo Filters::noXSS(CreateURL($do, 'newuserbulk')); ?><?php else: ?><?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?><?php endif; ?>" method="post" id="registernewuser">
+<?php if ($do == 'admin'): echo tpl_form(Filters::noXSS(CreateURL($do, 'newuserbulk')),null,null,null,'id="registernewuser"');
+                     else: echo tpl_form(Filters::noXSS($_SERVER['SCRIPT_NAME']),      null,null,null,'id="registernewuser"');
+endif; ?>
   <ul class="form_elements">
     <li class="required">
       <?php if ($do == 'admin'): ?>

--- a/themes/CleanFS/templates/common.profile.tpl
+++ b/themes/CleanFS/templates/common.profile.tpl
@@ -1,11 +1,3 @@
-<!--
-<form action="<?php
-if ($do == 'myprofile'):
-        echo Filters::noXSS(CreateUrl('myprofile'));
-else:
-        echo Filters::noXSS(CreateUrl('edituser', $theuser->id));
-endif; ?>" method="post" enctype="multipart/form-data">
--->
 <?php echo tpl_form( $do=='myprofile' ? Filters::noXSS(CreateUrl('myprofile')) : Filters::noXSS(CreateUrl('edituser', $theuser->id))); ?>
     <ul class="form_elements">
       <li>
@@ -13,62 +5,49 @@ endif; ?>" method="post" enctype="multipart/form-data">
         <input id="realname" class="text" type="text" name="real_name" size="50" maxlength="100"
           value="<?php echo Filters::noXSS(Req::val('real_name', $theuser->infos['real_name'])); ?>" />
       </li>
-
       <li>
         <label for="emailaddress"><?php echo Filters::noXSS(L('emailaddress')); ?></label>
         <input id="emailaddress" class="text" type="text" name="email_address" size="50" maxlength="100"
           value="<?php echo Filters::noXSS(Req::val('email_address', $theuser->infos['email_address'])); ?>" />
       </li>
-
       <li>
         <label for="hide_my_email"><?php echo Filters::noXSS(L('hidemyemail')); ?></label>
         <?php echo tpl_checkbox('hide_my_email', Req::val('hide_my_email', !Post::val('action') && $theuser->infos['hide_my_email']), 'hide_my_email'); ?>
       </li>
-
       <li>
         <label for="jabberid"><?php echo Filters::noXSS(L('jabberid')); ?></label>
         <input id="jabberid" class="text" type="text" name="jabber_id" size="50" maxlength="100"
           value="<?php echo Filters::noXSS(Req::val('jabber_id', $theuser->infos['jabber_id'])); ?>" />
         <input type="hidden" name="old_jabber_id" value="<?php echo Filters::noXSS($theuser->infos['jabber_id']); ?>" />
       </li>
-
       <li>
         <label for="profileimage"><?php echo Filters::noXSS(L('profileimage')); ?></label>
         <input id="profileimage" name="profile_image" type="file" value="<?php echo Filters::noXSS(Req::val('profile_image')); ?>"/>
       </li>
-
       <li>
         <label for="notifytype"><?php echo Filters::noXSS(L('notifytype')); ?></label>
         <select id="notifytype" name="notify_type">
-          <?php echo tpl_options($fs->GetNotificationOptions(),
-                              Req::val('notify_type', $theuser->infos['notify_type'])); ?>
-
+          <?php echo tpl_options($fs->GetNotificationOptions(), Req::val('notify_type', $theuser->infos['notify_type'])); ?>
         </select>
         <?php echo tpl_checkbox('notify_own', Req::val('notify_own', !Post::val('action') && $theuser->infos['notify_own']), 'notify_own'); ?>
-
         <label class="left notable" for="notify_own"><?php echo Filters::noXSS(L('notifyown')); ?></label>
       </li>
-
       <li>
         <label for="dateformat"><?php echo Filters::noXSS(L('dateformat')); ?></label>
         <input id="dateformat" class="text" name="dateformat" type="text" size="40" maxlength="30"
           value="<?php echo Filters::noXSS(Req::val('dateformat', $theuser->infos['dateformat'])); ?>" />
       </li>
-
       <li>
         <label for="dateformat_extended"><?php echo Filters::noXSS(L('dateformat_extended')); ?></label>
         <input id="dateformat_extended" class="text" name="dateformat_extended" type="text"
           size="40" maxlength="30" value="<?php echo Filters::noXSS(Req::val('dateformat_extended', $theuser->infos['dateformat_extended'])); ?>" />
       </li>
-
       <li>
         <label for="tasks_perpage"><?php echo Filters::noXSS(L('tasksperpage')); ?></label>
         <select name="tasks_perpage" id="tasks_perpage">
           <?php echo tpl_options(array(10, 25, 50, 100, 250), Req::val('tasks_perpage', $theuser->infos['tasks_perpage']), true); ?>
-
         </select>
       </li>
-
       <li>
         <label for="time_zone"><?php echo Filters::noXSS(L('timezone')); ?></label>
         <select id="time_zone" name="time_zone">
@@ -79,43 +58,33 @@ endif; ?>" method="post" enctype="multipart/form-data">
             }
           ?>
           <?php echo tpl_options($times, Req::val('time_zone', $theuser->infos['time_zone'])); ?>
-
         </select>
       </li>
-
-        <li>
+      <li>
             <label for="langcode"><?php echo Filters::noXSS(L('language')); ?></label>
             <select id="langcode" name="lang_code">
                 <?php echo tpl_options(Flyspray::listLangs(), Req::val('lang_code', $theuser->infos['lang_code']), true); ?>
-
             </select>
         </li>
-
       <li>
         <hr />
       </li>
-
       <?php if ($user->perms('is_admin')): ?>
       <li>
         <label for="accountenabled"><?php echo Filters::noXSS(L('accountenabled')); ?></label>
         <?php echo tpl_checkbox('account_enabled', Req::val('account_enabled', !Post::val('action') && $theuser->infos['account_enabled']), 'accountenabled'); ?>
-
       </li>
-
       <li>
         <label for="delete_user"><?php echo Filters::noXSS(L('deleteuser')); ?></label>
         <?php echo tpl_checkbox('delete_user', false, 'delete_user'); ?>
-
       </li>
       <?php endif; ?>
-
       <li>
         <label for="groupin"><?php echo Filters::noXSS(L('globalgroup')); ?></label>
         <select id="groupin" class="adminlist" name="group_in" <?php echo Filters::noXSS(tpl_disableif(!$user->perms('is_admin'))); ?>>
           <?php echo tpl_options($groups, Req::val('group_in', $theuser->infos['global_group'])); ?>
-
         </select>
-          <input type="hidden" name="old_global_id" value="<?php echo Filters::noXSS($theuser->infos['global_group']); ?>" />
+        <input type="hidden" name="old_global_id" value="<?php echo Filters::noXSS($theuser->infos['global_group']); ?>" />
       </li>
 
       <?php if ($proj->id): ?>
@@ -123,12 +92,10 @@ endif; ?>" method="post" enctype="multipart/form-data">
         <label for="projectgroupin"><?php echo Filters::noXSS(L('projectgroup')); ?></label>
         <select id="projectgroupin" class="adminlist" name="project_group_in" <?php echo Filters::noXSS(tpl_disableif(!$user->perms('manage_project'))); ?>>
           <?php echo tpl_options(array_merge($project_groups, array(0 => array('group_name' => L('none'), 0 => 0, 'group_id' => 0, 1 => L('none')))), Req::val('project_group_in', $theuser->perms('project_group'))); ?>
-
         </select>
           <input type="hidden" name="old_project_id" value="<?php echo Filters::noXSS($theuser->perms('project_group')); ?>" />
       </li>
       <?php endif; ?>
-
       <li>
         <hr />
       </li>
@@ -140,13 +107,10 @@ endif; ?>" method="post" enctype="multipart/form-data">
         <label for="oldpass"><?php echo Filters::noXSS(L('oldpass')); ?></label>
         <input id="oldpass" class="password" type="password" name="oldpass" value="<?php echo Filters::noXSS(Req::val('oldpass')); ?>" size="40" maxlength="100" />
       </li>
-
-
       <li>
         <label for="changepass"><?php echo Filters::noXSS(L('changepass')); ?></label>
         <input id="changepass" class="password" type="password" name="changepass" value="<?php echo Filters::noXSS(Req::val('changepass')); ?>" size="40" maxlength="100" />
       </li>
-
       <li>
         <label for="confirmpass"><?php echo Filters::noXSS(L('confirmpass')); ?></label>
         <input id="confirmpass" class="password" type="password" name="confirmpass" value="<?php echo Filters::noXSS(Req::val('confirmpass')); ?>" size="40" maxlength="100" />

--- a/themes/CleanFS/templates/details.edit.tpl
+++ b/themes/CleanFS/templates/details.edit.tpl
@@ -1,4 +1,4 @@
-<form action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>" id="taskeditform" enctype="multipart/form-data" method="post">
+<?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),null,null,null,'id="taskeditform"'); ?>
 <div id="actionbar">
 	<button class="button positive" type="submit" accesskey="s" onclick="return checkok('<?php echo Filters::noJsXSS($baseurl); ?>js/callbacks/checksave.php?time=<?php echo Filters::noXSS(time()); ?>&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>', '<?php echo Filters::noJsXSS(L('alreadyedited')); ?>', 'taskeditform')"><?php echo Filters::noXSS(L('savedetails')); ?></button>
 	<div class="clear"></div>

--- a/themes/CleanFS/templates/details.tabs.comment.tpl
+++ b/themes/CleanFS/templates/details.tabs.comment.tpl
@@ -26,10 +26,11 @@
         <?php endif; ?>
     
         <?php if ($user->perms('delete_comments')): ?>
-         |
-        <a href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?do=details&amp;action=details.deletecomment&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>&amp;comment_id=<?php echo Filters::noXSS($comment['comment_id']); ?>"
-          onclick="return confirm('<?php echo Filters::noJsXSS(L('confirmdeletecomment')); ?>');">
-          <?php echo Filters::noXSS(L('delete')); ?></a>
+        <?php echo tpl_form(CreateUrl('details', $task_details['task_id'])); ?>
+        <input type="hidden" name="action" value="details.deletecomment">
+        <input type="hidden" name="comment_id" value="<?php echo $comment['comment_id']; ?>">
+        <button type="submit" onclick="return confirm('<?php echo Filters::noJsXSS(L('confirmdeletecomment')); ?>');"><?php echo Filters::noXSS(L('delete')); ?></button>
+        </form>
         <?php endif ?>
       </span>
 

--- a/themes/CleanFS/templates/details.tabs.comment.tpl
+++ b/themes/CleanFS/templates/details.tabs.comment.tpl
@@ -63,7 +63,7 @@
 
   <?php if ($user->perms('add_comments') && (!$task_details['is_closed'] || $proj->prefs['comment_closed'])): ?>
   <h4><?php echo Filters::noXSS(L('addcomment')); ?></h4>
-  <form enctype="multipart/form-data" action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>" method="post">
+  <?php echo tpl_form(CreateUrl('details', $task_details['task_id']), 'comment', 'post', 'multipart/form-data'); ?>
     <div>
       <?php if (defined('FLYSPRAY_HAS_PREVIEW')): ?>
       <div class="hide preview" id="preview"></div>

--- a/themes/CleanFS/templates/details.tabs.efforttracking.tpl
+++ b/themes/CleanFS/templates/details.tabs.efforttracking.tpl
@@ -1,5 +1,5 @@
 <div id="effort" class="tab">
-    <form enctype="multipart/form-data" action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>" method="post">
+    <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])).'#effort'); ?>
         <input type="hidden" name="action" value="details.efforttracking"/>
         <button type="submit" name="start_tracking" value="true"><?php echo Filters::noXSS(L('starteffort')); ?></button>
         </br>

--- a/themes/CleanFS/templates/details.tabs.notifs.tpl
+++ b/themes/CleanFS/templates/details.tabs.notifs.tpl
@@ -1,10 +1,18 @@
 <div id="notify" class="tab">
   <p><em><?php echo Filters::noXSS(L('theseusersnotify')); ?></em></p>
   <?php foreach ($notifications as $row): ?>
-  <p>
-    <?php echo tpl_userlink($row['user_id']); ?> -
+  <div>
+    <?php echo tpl_userlink($row['user_id']); ?>
+<?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])).'#notify',null,null,null,'style="display:inline"'); ?>
+<input type="hidden" name="action" value="remove_notification" /> 
+<input type="hidden" name="ids" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
+<input type="hidden" name="user_id" value="<?php echo Filters::noXSS($row['user_id']); ?>" />
+<button type="submit"><?php echo Filters::noXSS(L('remove')); ?></button>
+</form>
+    <!--
     <a href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?do=details&amp;action=remove_notification&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>&amp;ids=<?php echo Filters::noXSS($task_details['task_id']); ?>&amp;user_id=<?php echo Filters::noXSS($row['user_id']); ?>#notify"><?php echo Filters::noXSS(L('remove')); ?></a>
-  </p>
+    -->
+  </div>
   <?php endforeach; ?>
 
   <?php if ($user->perms('manage_project')): ?>

--- a/themes/CleanFS/templates/details.tabs.notifs.tpl
+++ b/themes/CleanFS/templates/details.tabs.notifs.tpl
@@ -8,7 +8,7 @@
   <?php endforeach; ?>
 
   <?php if ($user->perms('manage_project')): ?>
-  <form action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>#notify" method="post">
+  <?php tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])).'#notify'); ?>
     <div>
         <label class="default multisel" for="notif_user_id"><?php echo Filters::noXSS(L('addusertolist')); ?></label>
         <?php echo tpl_userselect('user_name', Req::val('user_name'), 'notif_user_id'); ?>

--- a/themes/CleanFS/templates/details.tabs.notifs.tpl
+++ b/themes/CleanFS/templates/details.tabs.notifs.tpl
@@ -8,7 +8,7 @@
   <?php endforeach; ?>
 
   <?php if ($user->perms('manage_project')): ?>
-  <?php tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])).'#notify'); ?>
+  <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])).'#notify'); ?>
     <div>
         <label class="default multisel" for="notif_user_id"><?php echo Filters::noXSS(L('addusertolist')); ?></label>
         <?php echo tpl_userselect('user_name', Req::val('user_name'), 'notif_user_id'); ?>

--- a/themes/CleanFS/templates/details.tabs.related.tpl
+++ b/themes/CleanFS/templates/details.tabs.related.tpl
@@ -1,7 +1,7 @@
 <div id="related" class="tab">
   
   <div class="related">
-    <form method="post" action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>#related" >
+    <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])).'#related');?>
       <table id="tasks_related" class="userlist">
         <tr>
           <th>
@@ -43,7 +43,7 @@
   </div>
 
   <?php if ($user->can_edit_task($task_details) && !$task_details['is_closed']): ?>
-  <form class="clear" action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>#related" method="post" id="formaddrelatedtask">
+  <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])).'#related',null,null,null,'class="clear" id="formaddrelatedtask"'); ?>
     <div>
       <input type="hidden" name="action" value="details.add_related" />
       <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />

--- a/themes/CleanFS/templates/details.tabs.remind.tpl
+++ b/themes/CleanFS/templates/details.tabs.remind.tpl
@@ -1,7 +1,6 @@
 <?php if (!$task_details['is_closed']): ?>
   <div id="remind" class="tab">
-  
-  <form method="post" action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>#remind" >
+  <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])).'#remind'); ?>
     <?php if (count($reminders)): ?>
     <table id="reminders" class="userlist">
     <tr>
@@ -46,7 +45,7 @@
   </form>
 
   <fieldset><legend><?php echo Filters::noXSS(L('addreminder')); ?></legend>
-  <form action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>#remind" method="post" id="formaddreminder">
+  <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])).'#remind',null,null,null,'id="formaddreminder"'); ?>
     <div>
       <input type="hidden" name="action" value="details.addreminder" />
       <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
@@ -62,12 +61,8 @@
         <?php echo tpl_options(array(3600 => L('hours'), 86400 => L('days'), 604800 => L('weeks')), Req::val('timetype1')); ?>
 
       </select>
-
       <br />
-
       <?php echo tpl_datepicker('timeamount2', L('startat'), Req::val('timeamount2', formatDate(time()))); ?>
-
-
       <br />
       <textarea class="text" name="reminder_message"
         rows="10" cols="72"><?php echo Filters::noXSS(Req::val('reminder_message', L('defaultreminder') . "\n\n" . CreateURL('details', $task_details['task_id']))); ?></textarea>

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -88,8 +88,12 @@
     <?php endif; ?>
 
     <?php if ($user->can_take_ownership($task_details)): ?>
-    <a id="own" class="button"
-       href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?do=details&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>&amp;action=takeownership&amp;ids=<?php echo Filters::noXSS($task_details['task_id']); ?>"> <?php echo Filters::noXSS(L('assigntome')); ?></a>
+    <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id']))); ?>
+      <input type="hidden" name="action" value="takeownership" /> 
+      <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
+      <input type="hidden" name="ids" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
+      <button type="submit" id="own"><?php echo Filters::noXSS(L('assigntome')); ?></button>
+    </form>
     <?php endif; ?>
 
     <?php if ($user->can_add_to_assignees($task_details) && !empty($task_details['assigned_to'])): ?>
@@ -118,7 +122,7 @@
             </li> 
             <?php endif; ?>
             <?php if ($user->can_edit_task($task_details)): ?>
-            <li><input type="checkbox" id="s_assosciate"><label for="s_associate"><?php echo Filters::noXSS(L('associatesubtask')); ?></label>
+            <li><input type="checkbox" id="s_associate"><label for="s_associate"><?php echo Filters::noXSS(L('associatesubtask')); ?></label>
               <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),null.null,null,'id="associateform"'); ?>
               <?php echo Filters::noXSS(L('associatetaskid')); ?>
               <input type="hidden" name="action" value="details.associatesubtask"/>

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -123,7 +123,7 @@
             <?php endif; ?>
             <?php if ($user->can_edit_task($task_details)): ?>
             <li><input type="checkbox" id="s_associate"><label for="s_associate"><?php echo Filters::noXSS(L('associatesubtask')); ?></label>
-              <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),null.null,null,'id="associateform"'); ?>
+              <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),null,null,null,'id="associateform"'); ?>
               <?php echo Filters::noXSS(L('associatetaskid')); ?>
               <input type="hidden" name="action" value="details.associatesubtask"/>
               <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -5,9 +5,9 @@
        href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?do=details&amp;action=reopen&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>"><?php echo Filters::noXSS(L('reopenthistask')); ?></a>
     <?php elseif (!$user->isAnon() && !Flyspray::adminRequestCheck(2, $task_details['task_id'])): ?>
     <div id="closeform" class="popup hide">
-        <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id']))),'form3',null,null,'id="formclosetask"'); ?>
-            <input type="hidden" name="action" value="requestreopen"/>
-            <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
+        <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),'form3',null,null,'id="formclosetask"'); ?>
+            <input type="hidden" name="action" value="requestreopen" />
+            <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
             <label for="reason"><?php echo Filters::noXSS(L('reasonforreq')); ?></label>
             <textarea id="reason" name="reason_given"></textarea><br/>
             <button type="submit"><?php echo Filters::noXSS(L('submitreq')); ?></button>

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -118,41 +118,28 @@
             </li> 
             <?php endif; ?>
             <?php if ($user->can_edit_task($task_details)): ?>
-            <li>
-                <a href="#" onclick="showhidestuff('associateform');"><?php echo Filters::noXSS(L('associatesubtask')); ?></a>
-
-                <div id="associateform" class="hide">
-                    <br>
-                    <form action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>" method="post">
-                        <?php echo Filters::noXSS(L('associatetaskid')); ?>
-
-                        <input type="hidden" name="action" value="details.associatesubtask"/>
-                        <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
-                        <input class="text" type="text" value="" id="associate_subtask_id" name="associate_subtask_id"
-                               size="5" maxlength="10"/>
-                        <button type="submit" name="submit"><?php echo Filters::noXSS(L('set')); ?></button>
-                    </form>
-                    </br>
-                </div>
+            <li><input type="checkbox" id="s_assosciate"><label for="s_associate"><?php echo Filters::noXSS(L('associatesubtask')); ?></label>
+              <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),null.null,null,'id="associateform"'); ?>
+              <?php echo Filters::noXSS(L('associatetaskid')); ?>
+              <input type="hidden" name="action" value="details.associatesubtask"/>
+              <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
+              <input class="text" type="text" value="" id="associate_subtask_id" name="associate_subtask_id" size="5" maxlength="10"/>
+              <button type="submit" name="submit"><?php echo Filters::noXSS(L('set')); ?></button>
+              </form>
             </li>
             <?php endif; ?>
             <li>
                 <a href="<?php echo Filters::noXSS(CreateURL('depends', $task_details['task_id'])); ?>"><?php echo Filters::noXSS(L('depgraph')); ?></a>
             </li>
             <?php if ($user->can_edit_task($task_details)): ?>
-            <li>
-                <a href="#" onclick="showhidestuff('adddepform');"><?php echo Filters::noXSS(L('adddependenttask')); ?></a>
-                <div id="adddepform" class="hide">
-                    <br>
-                    <form action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>" method="post">
-                        <label for="dep_task_id"><?php echo Filters::noXSS(L('newdependency')); ?></label>
-                        <input type="hidden" name="action" value="details.newdep" />
-                        <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
-                        <input class="text" type="text" value="<?php echo Filters::noXSS(Req::val('dep_task_id')); ?>" id="dep_task_id" name="dep_task_id" size="5" maxlength="10" />
-                        <button type="submit" name="submit"><?php echo Filters::noXSS(L('add')); ?></button>
-                    </form>
-                    </br>
-                </div>
+            <li><input type="checkbox" id="s_adddependent"><label for="s_adddependent"><?php echo Filters::noXSS(L('adddependenttask')); ?></label>
+              <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),null,null,null,'id="adddepform"'); ?>
+              <label for="dep_task_id"><?php echo Filters::noXSS(L('newdependency')); ?></label>
+              <input type="hidden" name="action" value="details.newdep" />
+              <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
+              <input class="text" type="text" value="<?php echo Filters::noXSS(Req::val('dep_task_id')); ?>" id="dep_task_id" name="dep_task_id" size="5" maxlength="10" />
+              <button type="submit" name="submit"><?php echo Filters::noXSS(L('add')); ?></button>
+              </form>
             </li>
             <?php endif; ?>
 

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -150,11 +150,14 @@
             <?php endif; ?>
 
             <?php if ($user->can_take_ownership($task_details)): ?>
-            <li>
-                <a href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?do=details&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>&amp;action=takeownership&amp;ids=<?php echo Filters::noXSS($task_details['task_id']); ?>"> <?php echo Filters::noXSS(L('assigntome')); ?></a>
+            <li><?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id']))); ?>
+              <input type="hidden" name="action" value="takeownership" />
+              <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
+              <input type="hidden" name="ids" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
+              <button type="submit"><?php echo Filters::noXSS(L('assigntome')); ?></button>
+              </form>
             </li>
             <?php endif; ?>
-
 
             <?php if ($user->can_add_to_assignees($task_details) && !empty($task_details['assigned_to'])): ?>
             <li>

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -107,23 +107,15 @@
             <?php endif; ?>
 
             <?php if ($user->can_edit_task($task_details)): ?>
-            <li>
-                <a href="#" onclick="showhidestuff('setparentform');"><?php echo Filters::noXSS(L('setparent')); ?></a>
-
-                <div id="setparentform" class="hide">
-                    </br>
-                    <form action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>" method="post">
-                        <?php echo Filters::noXSS(L('parenttaskid')); ?>
-
-                        <input type="hidden" name="action" value="details.setparent"/>
-                        <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
-                        <input class="text" type="text" value="" id="supertask_id" name="supertask_id" size="5"
-                               maxlength="10"/>
-                        <button type="submit" name="submit"><?php echo Filters::noXSS(L('set')); ?></button>
-                    </form>
-                    </br>
-                </div>
-            </li>
+            <li><input type="checkbox" id="s_parent"><label for="s_parent"><?php echo Filters::noXSS(L('setparent')); ?></label>
+                <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),null,null,null,'id="setparentform"'); ?> 
+                <?php echo Filters::noXSS(L('parenttaskid')); ?>
+                <input type="hidden" name="action" value="details.setparent" />
+                <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" /> 
+                <input class="text" type="text" value="" id="supertask_id" name="supertask_id" size="5" maxlength="10" />
+                <button type="submit" name="submit"><?php echo Filters::noXSS(L('set')); ?></button>
+                </form>
+            </li> 
             <?php endif; ?>
             <?php if ($user->can_edit_task($task_details)): ?>
             <li>

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -346,21 +346,14 @@ function quick_edit(elem, id)
     <ul class="fieldslist">
         <!-- Task Type-->
         <?php if (in_array('tasktype', $fields)): ?>
-        <li>
-            <span class="label"><?php echo Filters::noXSS(L('tasktype')); ?></span>
-            <span <?php if ($user->can_edit_task($task_details)): ?>onclick="show_hide(this, true)"<?php endif;?> class="value"><?php echo Filters::noXSS($task_details['tasktype_name']); ?></span>
-
-	<?php if ($user->can_edit_task($task_details)): ?>
-		<span style="display:none">
-			<div style="float:right"><select id="tasktype" name="task_type">
-			<?php echo tpl_options($proj->listTaskTypes(), Req::val('task_type', $task_details['task_type'])); ?>
-
-			</select>
-			<a onclick="quick_edit(this.parentNode.parentNode, 'tasktype')" href="javascript:void(0)" class="button"></a><?php echo Filters::noXSS(L('confirmedit')); ?></a><a href="javascript:void(0)" onclick="show_hide(this.parentNode.parentNode, false)" class="button"><?php echo Filters::noXSS(L('canceledit')); ?></a></div>
-		</span>
-        <?php endif; ?>
-
-        </li>
+        <li><span class="label"><?php echo Filters::noXSS(L('tasktype')); ?></span><span class="value<?php if ($user->can_edit_task($task_details)): ?> canedit<?php endif;?><?php echo Filters::noXSS($task_details['tasktype_name']); ?></span>
+	<?php if ($user->can_edit_task($task_details)):
+	?><span class="editquick" style="display:none;">
+		<span class="editvalue"><select id="tasktype" name="task_type">
+		<?php echo tpl_options($proj->listTaskTypes(), Req::val('task_type', $task_details['task_type'])); ?>
+		</select>
+		<a onclick="quick_edit(this.parentNode.parentNode, 'tasktype')" href="javascript:void(0)" class="button"><?php echo Filters::noXSS(L('confirmedit')); ?></a></span>
+	</span><?php endif; ?></li>
         <?php endif; ?>
 
         <!-- Category -->

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -1,56 +1,44 @@
 <div id="actionbar">
-    <?php if ($task_details['is_closed']): //if task is closed ?>
-
-    <?php if ($user->can_close_task($task_details)): ?>
+<?php if ($task_details['is_closed']): //if task is closed ?>
+  <?php if ($user->can_close_task($task_details)): ?>
     <a class="button"
        href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?do=details&amp;action=reopen&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>"><?php echo Filters::noXSS(L('reopenthistask')); ?></a>
     <?php elseif (!$user->isAnon() && !Flyspray::adminRequestCheck(2, $task_details['task_id'])): ?>
-    <a href="#close" id="reqclose" class="button" onclick="showhidestuff('closeform');"><?php echo Filters::noXSS(L('reopenrequest')); ?></a>
-
     <div id="closeform" class="popup hide">
-        <form name="form3" action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>" method="post" id="formclosetask">
-            <div>
-                <input type="hidden" name="action" value="requestreopen"/>
-                <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
-                <label for="reason"><?php echo Filters::noXSS(L('reasonforreq')); ?></label>
-                <textarea id="reason" name="reason_given"></textarea><br/>
-                <button type="submit"><?php echo Filters::noXSS(L('submitreq')); ?></button>
-            </div>
-        </form>
+        <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id']))),'form3',null,null,'id="formclosetask"'); ?>
+            <input type="hidden" name="action" value="requestreopen"/>
+            <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
+            <label for="reason"><?php echo Filters::noXSS(L('reasonforreq')); ?></label>
+            <textarea id="reason" name="reason_given"></textarea><br/>
+            <button type="submit"><?php echo Filters::noXSS(L('submitreq')); ?></button>
+        </form> 
     </div>
-    <?php endif; ?>
-
-    <?php else:  //if task is open  ?>
-
-    <?php if ($user->can_close_task($task_details) && !$d_open): ?>
+  <?php endif; ?>
+<?php else:  //if task is open  ?>
+  <?php if ($user->can_close_task($task_details) && !$d_open): ?>
     <a href="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'], null, array('showclose' => !Req::val('showclose')))); ?>"
        id="closetask" class="button main" accesskey="y"
        onclick="showhidestuff('closeform');return false;"> <?php echo Filters::noXSS(L('closetask')); ?></a>
 
-    <div id="closeform"
-         class="<?php if (Req::val('action') != 'details.close' && !Req::val('showclose')): ?>hide <?php endif; ?>popup">
-        <form action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>" method="post" id="formclosetask">
-            <div>
-                <input type="hidden" name="action" value="details.close"/>
-                <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
-                <select class="adminlist" name="resolution_reason" onmouseup="Event.stop(event);">
-                    <option value="0"><?php echo Filters::noXSS(L('selectareason')); ?></option>
-                    <?php echo tpl_options($proj->listResolutions(), Req::val('resolution_reason')); ?>
-
-                </select>
-                <button type="submit"><?php echo Filters::noXSS(L('closetask')); ?></button>
-                <br/>
-                <label class="default text" for="closure_comment"><?php echo Filters::noXSS(L('closurecomment')); ?></label>
-                <textarea class="text" id="closure_comment" name="closure_comment" rows="3"
-                          cols="25"><?php echo Filters::noXSS(Req::val('closure_comment')); ?></textarea>
-                <?php if($task_details['percent_complete'] != '100'): ?>
-                <label><?php echo tpl_checkbox('mark100', Req::val('mark100', !(Req::val('action') == 'details.close'))); ?>&nbsp;&nbsp;<?php echo Filters::noXSS(L('mark100')); ?></label>
-                <?php endif; ?>
-            </div>
-        </form>
+    <div id="closeform" class="<?php if (Req::val('action') != 'details.close' && !Req::val('showclose')): ?>hide <?php endif; ?>popup">
+        <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),null,null,null,'id="formclosetask"'); ?>
+        <input type="hidden" name="action" value="details.close"/>
+        <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
+        <select class="adminlist" name="resolution_reason" onmouseup="Event.stop(event);">
+        <option value="0"><?php echo Filters::noXSS(L('selectareason')); ?></option>
+        <?php echo tpl_options($proj->listResolutions(), Req::val('resolution_reason')); ?>
+        </select>
+        <button type="submit"><?php echo Filters::noXSS(L('closetask')); ?></button>
+        <br/>   
+        <label class="default text" for="closure_comment"><?php echo Filters::noXSS(L('closurecomment')); ?></label>
+        <textarea class="text" id="closure_comment" name="closure_comment" rows="3" cols="25"><?php echo Filters::noXSS(Req::val('closure_comment')); ?></textarea>
+        <?php if($task_details['percent_complete'] != '100'): ?>
+        <label><?php echo tpl_checkbox('mark100', Req::val('mark100', !(Req::val('action') == 'details.close'))); ?>&nbsp;&nbsp;<?php echo Filters::noXSS(L('mark100')); ?></label>
+        <?php endif; ?>
+        </form> 
     </div>
 
-    <?php elseif (!$d_open && !$user->isAnon() && !Flyspray::AdminRequestCheck(1, $task_details['task_id'])): ?>
+  <?php elseif (!$d_open && !$user->isAnon() && !Flyspray::AdminRequestCheck(1, $task_details['task_id'])): ?>
     <a href="#close" id="reqclose" class="button main" onclick="showhidestuff('closeform');"><?php echo Filters::noXSS(L('requestclose')); ?></a>
 
     <div id="closeform" class="popup hide">
@@ -64,7 +52,7 @@
             </div>
         </form>
     </div>
-    <?php elseif(!$user->isAnon()): ?>
+  <?php elseif(!$user->isAnon()): ?>
     <a href="#closedisabled" id="reqclose" class="tooltip button disabled main"><?php echo Filters::noXSS(L('closetask')); ?>
 
     <span class="custom info">
@@ -80,26 +68,26 @@
                     ?>
                 </span>
     </a>
-    <?php endif; ?>
+  <?php endif; ?>
 
-    <?php if ($user->can_edit_task($task_details)): ?>
+  <?php if ($user->can_edit_task($task_details)): ?>
     <a id="edittask" class="button" accesskey="e"
        href="<?php echo Filters::noXSS(CreateURL('edittask', $task_details['task_id'])); ?>"> <?php echo Filters::noXSS(L('edittask')); ?></a>
-    <?php endif; ?>
+  <?php endif; ?>
 
-    <?php if ($user->can_take_ownership($task_details)): ?>
+  <?php if ($user->can_take_ownership($task_details)): ?>
     <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id']))); ?>
       <input type="hidden" name="action" value="takeownership" /> 
       <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
       <input type="hidden" name="ids" value="<?php echo Filters::noXSS($task_details['task_id']); ?>" />
       <button type="submit" id="own"><?php echo Filters::noXSS(L('assigntome')); ?></button>
     </form>
-    <?php endif; ?>
+  <?php endif; ?>
 
-    <?php if ($user->can_add_to_assignees($task_details) && !empty($task_details['assigned_to'])): ?>
+  <?php if ($user->can_add_to_assignees($task_details) && !empty($task_details['assigned_to'])): ?>
     <a id="own_add" class="button"
        href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?do=details&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>&amp;action=addtoassignees&amp;ids=<?php echo Filters::noXSS($task_details['task_id']); ?>"> <?php echo Filters::noXSS(L('addmetoassignees')); ?></a>
-    <?php endif; ?>
+  <?php endif; ?>
 	<input type="checkbox" id="s_quickactions">
 	<label class="button main" id="actions" for="s_quickactions"><?php echo Filters::noXSS(L('quickaction')); ?></label>
 	<div id="actionsform">
@@ -194,11 +182,10 @@
 
         </ul>
 	</div>
-    <?php endif; ?>
+<?php endif; ?>
 </div>
 
 <script type="text/javascript">
-
 function show_hide(elem, flag)
 {
 	elem.style.display = "none";

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -40,18 +40,16 @@
 
   <?php elseif (!$d_open && !$user->isAnon() && !Flyspray::AdminRequestCheck(1, $task_details['task_id'])): ?>
     <a href="#close" id="reqclose" class="button main" onclick="showhidestuff('closeform');"><?php echo Filters::noXSS(L('requestclose')); ?></a>
-
     <div id="closeform" class="popup hide">
-        <form name="form3" action="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>" method="post" id="formclosetask">
-            <div>
-                <input type="hidden" name="action" value="requestclose"/>
-                <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
-                <label for="reason"><?php echo Filters::noXSS(L('reasonforreq')); ?></label>
-                <textarea id="reason" name="reason_given"></textarea><br/>
-                <button type="submit"><?php echo Filters::noXSS(L('submitreq')); ?></button>
-            </div>
-        </form>
+    <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),'form3',null,null,'id="formclosetask"'); ?>
+      <input type="hidden" name="action" value="requestclose"/>
+      <input type="hidden" name="task_id" value="<?php echo Filters::noXSS($task_details['task_id']); ?>"/>
+      <label for="reason"><?php echo Filters::noXSS(L('reasonforreq')); ?></label>
+      <textarea id="reason" name="reason_given"></textarea><br/>
+      <button type="submit"><?php echo Filters::noXSS(L('submitreq')); ?></button>
+    </form>
     </div>
+
   <?php elseif(!$user->isAnon()): ?>
     <a href="#closedisabled" id="reqclose" class="tooltip button disabled main"><?php echo Filters::noXSS(L('closetask')); ?>
 

--- a/themes/CleanFS/templates/editcomment.tpl
+++ b/themes/CleanFS/templates/editcomment.tpl
@@ -1,7 +1,7 @@
 <h3><?php echo Filters::noXSS(L('editcomment')); ?></h3>
 <div class="box">
-<form action="<?php echo Filters::noXSS(CreateUrl('details', $comment['task_id'])); ?>" enctype="multipart/form-data" method="post">
-    <div>
+<?php echo tpl_form(CreateUrl('details', $comment['task_id'])); ?>
+  <div>
     <p><?php echo Filters::noXSS(L('commentby')); ?> <?php echo Filters::noXSS($comment['real_name']); ?> - <?php echo Filters::noXSS(formatDate($comment['date_added'], true)); ?></p>
     <?php 
     $attachments = $proj->listAttachments($comment['comment_id']);

--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -69,32 +69,29 @@
 <?php if (!($user->isAnon() && count($fs->projects) == 0)): ?>
 <?php $filter = false; if($proj->id > 0) { $filter = true; $fields = explode( ' ', $proj->prefs['visible_fields'] );} ?>
 <form id="search" action="<?php echo Filters::noXSS($baseurl); ?>index.php" method="get">
-<button id="searchthisproject" type="submit"><?php echo Filters::noXSS(L('searchthisproject')); ?></button>
-<input class="text" id="searchtext" name="string" type="text" size="20"
+  <button id="searchthisproject" type="submit"><?php echo Filters::noXSS(L('searchthisproject')); ?></button>
+  <input class="text" id="searchtext" name="string" type="text" size="20"
    maxlength="100" value="<?php echo Filters::noXSS(Get::val('string')); ?>" accesskey="q"/>
-<input type="hidden" name="project" value="<?php echo Filters::noXSS(Get::num('project', $proj->id)); ?>"/>
-<a class="button" id="searchstate" onclick="toggleSearchBox('<?php echo Filters::noJsXSS($this->themeUrl()); ?>');return false;"
-   href="<?php echo Filters::noXSS(CreateUrl('project', $proj->id, null, array_merge($_GET, array('toggleadvanced' => 1)))); ?>">
-	<span id="advancedsearchstate" class="showstate"><img id="advancedsearchstateimg"
-                src="<?php echo (Cookie::val('advancedsearch')) ? $this->get_image('edit_remove') : $this->get_image('edit_add'); ?>"
-                alt="<?php echo (Cookie::val('advancedsearch')) ? '-' : '+'; ?>"/>
-	</span><?php echo Filters::noXSS(L('advanced')); ?></a>
-<div id="sc2" class="switchcontent"
-        <?php if (!Cookie::val('advancedsearch')):?>style="display:none;"<?php endif; ?> >
-        <?php if (!$user->isAnon()): ?>
-                <fieldset>
-                    <div class="save_search"><label for="save_search" id="lblsaveas"><?php echo Filters::noXSS(L('saveas')); ?></label>
-                        <input class="text" type="text" value="<?php echo Filters::noXSS(Get::val('search_name')); ?>" id="save_search"
-                               name="search_name" size="15"/>
-                        &nbsp;
-                        <button onclick="savesearch('<?php echo Filters::escapeqs($_SERVER['QUERY_STRING']); ?>', '<?php echo Filters::noJsXSS($baseurl); ?>', '<?php echo Filters::noXSS(L('saving')); ?>')"
-                                type="button"><?php echo Filters::noXSS(L('OK')); ?></button>
-                    </div>
-                </fieldset>
-                <?php endif; ?>
-                <fieldset class="advsearch_misc">
-                    <legend><?php echo Filters::noXSS(L('miscellaneous')); ?></legend>
-                    <?php echo tpl_checkbox('search_in_comments', Get::has('search_in_comments'), 'sic'); ?>
+  <input type="hidden" name="project" value="<?php echo Filters::noXSS(Get::num('project', $proj->id)); ?>"/>
+<style>
+#sc2,#s_searchstate{display:none;}
+#s_searchstate:checked ~ #sc2 {display:block;}
+</style>
+<input id="s_searchstate" type="checkbox" name="advancedsearch"<?php if(Req::val('advancedsearch')): ?> checked="checked"<?php endif; ?>>
+<label id="searchstateactions" class="button main" for="s_searchstate"><?php echo Filters::noXSS(L('advanced')); ?></label>
+<div id="sc2" class="switchcontent">
+<?php if (!$user->isAnon()): ?>
+<div id="sc2" class="switchcontent">
+<?php if (!$user->isAnon()): ?>
+<fieldset>
+  <div class="save_search"><label for="save_search" id="lblsaveas"><?php echo Filters::noXSS(L('saveas'));?></label>
+   <input class="text" type="text" value="<?php echo Filters::noXSS(Get::val('search_name')); ?>" id="save_search" name="search_name" size="15"/> <button onclick="savesearch('<?php echo Filters::escapeqs($_SERVER['QUERY_STRING']); ?>', '<?php echo Filters::noJsXSS($baseurl); ?>', '<?php echo Filters::noXSS(L('saving')); ?>')" type="button"><?php echo Filters::noXSS(L('OK')); ?></button>
+  </div>
+</fieldset>
+<?php endif; ?>
+<fieldset class="advsearch_misc">
+   <legend><?php echo Filters::noXSS(L('miscellaneous')); ?></legend>
+   <?php echo tpl_checkbox('search_in_comments', Get::has('search_in_comments'), 'sic'); ?>
                     <label class="left" for="sic"><?php echo Filters::noXSS(L('searchcomments')); ?></label>
 
                     <?php echo tpl_checkbox('search_in_details', Get::has('search_in_details'), 'search_in_details'); ?>

--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -68,9 +68,7 @@
 
 <?php if (!($user->isAnon() && count($fs->projects) == 0)): ?>
 <?php $filter = false; if($proj->id > 0) { $filter = true; $fields = explode( ' ', $proj->prefs['visible_fields'] );} ?>
-<div id="search">
-    <map id="projectsearchform" name="projectsearchform">
-        <form action="<?php echo Filters::noXSS($baseurl); ?>index.php" method="get">
+<form id="search" action="<?php echo Filters::noXSS($baseurl); ?>index.php" method="get">
             <div>
                 <button id="searchthisproject" type="submit"><?php echo Filters::noXSS(L('searchthisproject')); ?></button>
                 <input class="text" id="searchtext" name="string" type="text" size="20"
@@ -302,18 +300,10 @@
 
             </div>
             <input type="hidden" name="do" value="index"/>
-
- <!--- Added 2/1/2014 LAE --!>
-
- <form action="<?php echo Filters::noXSS($baseurl); ?>/scripts/index.php" method="post">
- <input type='submit' name='export_list' value='<?php echo Filters::noXSS(L('exporttasklist')); ?>'>
- </form>
-
-</div>
-
 </form>
-</map>
-</div>
+<form action="<?php echo Filters::noXSS($baseurl); ?>/scripts/index.php" method="post">
+<input type='submit' name='export_list' value='<?php echo Filters::noXSS(L('exporttasklist')); ?>'>
+</form>
 <?php endif; ?>
 
 <div id="tasklist">

--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -73,7 +73,7 @@
 <input class="text" id="searchtext" name="string" type="text" size="20"
    maxlength="100" value="<?php echo Filters::noXSS(Get::val('string')); ?>" accesskey="q"/>
 <input type="hidden" name="project" value="<?php echo Filters::noXSS(Get::num('project', $proj->id)); ?>"/>
-<a id="searchstate" onclick="toggleSearchBox('<?php echo Filters::noJsXSS($this->themeUrl()); ?>');return false;"
+<a class="button" id="searchstate" onclick="toggleSearchBox('<?php echo Filters::noJsXSS($this->themeUrl()); ?>');return false;"
    href="<?php echo Filters::noXSS(CreateUrl('project', $proj->id, null, array_merge($_GET, array('toggleadvanced' => 1)))); ?>">
 	<span id="advancedsearchstate" class="showstate"><img id="advancedsearchstateimg"
                 src="<?php echo (Cookie::val('advancedsearch')) ? $this->get_image('edit_remove') : $this->get_image('edit_add'); ?>"

--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -69,29 +69,19 @@
 <?php if (!($user->isAnon() && count($fs->projects) == 0)): ?>
 <?php $filter = false; if($proj->id > 0) { $filter = true; $fields = explode( ' ', $proj->prefs['visible_fields'] );} ?>
 <form id="search" action="<?php echo Filters::noXSS($baseurl); ?>index.php" method="get">
-            <div>
-                <button id="searchthisproject" type="submit"><?php echo Filters::noXSS(L('searchthisproject')); ?></button>
-                <input class="text" id="searchtext" name="string" type="text" size="20"
-                       maxlength="100" value="<?php echo Filters::noXSS(Get::val('string')); ?>" accesskey="q"/>
-
-                <input type="hidden" name="project" value="<?php echo Filters::noXSS(Get::num('project', $proj->id)); ?>"/>
-
-        <span id="searchstate" style="cursor:pointer">
-	        <a onclick="toggleSearchBox('<?php echo Filters::noJsXSS($this->themeUrl()); ?>');return false;"
-               href="<?php echo Filters::noXSS(CreateUrl('project', $proj->id, null, array_merge($_GET, array('toggleadvanced' => 1)))); ?>">
-						<span id="advancedsearchstate" class="showstate">
-							<img id="advancedsearchstateimg"
-                                 src="<?php echo (Cookie::val('advancedsearch')) ? $this->get_image('edit_remove') : $this->get_image('edit_add'); ?>"
-                                 alt="<?php echo (Cookie::val('advancedsearch')) ? '-' : '+'; ?>"/>
-						</span><?php echo Filters::noXSS(L('advanced')); ?>
-
-            </a>
-        </span>
-
-                <div id="sc2" class="switchcontent"
-                <?php if (!Cookie::val('advancedsearch')):?>style="display:none;"<?php endif; ?> >
-
-                <?php if (!$user->isAnon()): ?>
+<button id="searchthisproject" type="submit"><?php echo Filters::noXSS(L('searchthisproject')); ?></button>
+<input class="text" id="searchtext" name="string" type="text" size="20"
+   maxlength="100" value="<?php echo Filters::noXSS(Get::val('string')); ?>" accesskey="q"/>
+<input type="hidden" name="project" value="<?php echo Filters::noXSS(Get::num('project', $proj->id)); ?>"/>
+<a id="searchstate" onclick="toggleSearchBox('<?php echo Filters::noJsXSS($this->themeUrl()); ?>');return false;"
+   href="<?php echo Filters::noXSS(CreateUrl('project', $proj->id, null, array_merge($_GET, array('toggleadvanced' => 1)))); ?>">
+	<span id="advancedsearchstate" class="showstate"><img id="advancedsearchstateimg"
+                src="<?php echo (Cookie::val('advancedsearch')) ? $this->get_image('edit_remove') : $this->get_image('edit_add'); ?>"
+                alt="<?php echo (Cookie::val('advancedsearch')) ? '-' : '+'; ?>"/>
+	</span><?php echo Filters::noXSS(L('advanced')); ?></a>
+<div id="sc2" class="switchcontent"
+        <?php if (!Cookie::val('advancedsearch')):?>style="display:none;"<?php endif; ?> >
+        <?php if (!$user->isAnon()): ?>
                 <fieldset>
                     <div class="save_search"><label for="save_search" id="lblsaveas"><?php echo Filters::noXSS(L('saveas')); ?></label>
                         <input class="text" type="text" value="<?php echo Filters::noXSS(Get::val('search_name')); ?>" id="save_search"
@@ -102,41 +92,31 @@
                     </div>
                 </fieldset>
                 <?php endif; ?>
-
-
                 <fieldset class="advsearch_misc">
                     <legend><?php echo Filters::noXSS(L('miscellaneous')); ?></legend>
                     <?php echo tpl_checkbox('search_in_comments', Get::has('search_in_comments'), 'sic'); ?>
-
                     <label class="left" for="sic"><?php echo Filters::noXSS(L('searchcomments')); ?></label>
 
                     <?php echo tpl_checkbox('search_in_details', Get::has('search_in_details'), 'search_in_details'); ?>
-
                     <label class="left" for="search_in_details"><?php echo Filters::noXSS(L('searchindetails')); ?></label>
 
                     <?php echo tpl_checkbox('search_for_all', Get::has('search_for_all'), 'sfa'); ?>
-
                     <label class="left" for="sfa"><?php echo Filters::noXSS(L('searchforall')); ?></label>
 
                     <?php echo tpl_checkbox('only_watched', Get::has('only_watched'), 'only_watched'); ?>
-
                     <label class="left" for="only_watched"><?php echo Filters::noXSS(L('taskswatched')); ?></label>
 
                     <?php echo tpl_checkbox('only_primary', Get::has('only_primary'), 'only_primary'); ?>
-
                     <label class="left" for="only_primary"><?php echo Filters::noXSS(L('onlyprimary')); ?></label>
 
                     <?php echo tpl_checkbox('has_attachment', Get::has('has_attachment'), 'has_attachment'); ?>
-
                     <label class="left" for="has_attachment"><?php echo Filters::noXSS(L('hasattachment')); ?></label>
 
                     <?php echo tpl_checkbox('hide_subtasks', Get::has('hide_subtasks'), 'hide_subtasks'); ?>
-
                     <label class="left" for="hide_subtasks"><?php echo Filters::noXSS(L('hidesubtasks')); ?></label>
                 </fieldset>
 
                 <fieldset class="advsearch_task">
-
                     <legend><?php echo Filters::noXSS(L('taskproperties')); ?></legend>
             <!-- Task Type -->
 		    <?php if (!$filter || in_array('tasktype', $fields)) { ?>
@@ -147,7 +127,6 @@
                         <label class="default multisel" for="type"><?php echo Filters::noXSS(L('tasktype')); ?></label>
                         <select name="type[]" id="type" multiple="multiple" size="5">
                             <?php echo tpl_options(array('' => L('alltasktypes')) + $proj->listTaskTypes(), Get::val('type', '')); ?>
-
                         </select>
                     </div>
 
@@ -160,7 +139,6 @@
                         <label class="default multisel" for="sev"><?php echo Filters::noXSS(L('severity')); ?></label>
                         <select name="sev[]" id="sev" multiple="multiple" size="5">
                             <?php echo tpl_options(array('' => L('allseverities')) + $fs->severities, Get::val('sev', '')); ?>
-
                         </select>
                     </div>
 
@@ -173,7 +151,6 @@
                         <label class="default multisel" for="pri"><?php echo Filters::noXSS(L('priority')); ?></label>
                         <select name="pri[]" id="pri" multiple="multiple" size="5">
                             <?php echo tpl_options(array('' => L('allpriorities')) + $fs->priorities, Get::val('pri', '')); ?>
-
                         </select>
                     </div>
 
@@ -186,7 +163,6 @@
                         <label class="default multisel" for="due"><?php echo Filters::noXSS(L('dueversion')); ?></label>
                         <select name="due[]" id="due" multiple="multiple" size="5">
                             <?php echo tpl_options(array_merge(array('' => L('dueanyversion'), 0 => L('unassigned')), $proj->listVersions(false)), Get::val('due', '')); ?>
-
                         </select>
                     </div>
 
@@ -199,7 +175,6 @@
                         <label class="default multisel" for="reported"><?php echo Filters::noXSS(L('reportedversion')); ?></label>
                         <select name="reported[]" id="reported" multiple="multiple" size="5">
                             <?php echo tpl_options(array('' => L('anyversion')) + $proj->listVersions(false), Get::val('reported', '')); ?>
-
                         </select>
                     </div>
 
@@ -212,7 +187,6 @@
                         <label class="default multisel" for="cat"><?php echo Filters::noXSS(L('category')); ?></label>
                         <select name="cat[]" id="cat" multiple="multiple" size="5">
                             <?php echo tpl_options(array('' => L('allcategories')) + $proj->listCategories(), Get::val('cat', '')); ?>
-
                         </select>
                     </div>
 
@@ -228,7 +202,6 @@
                             array('open' => L('allopentasks')) +
                             array('closed' => L('allclosedtasks')) +
                             $proj->listTaskStatuses(), Get::val('status', 'open')); ?>
-
                         </select>
                     </div>
 
@@ -242,7 +215,6 @@
                         <select name="percent[]" id="percent" multiple="multiple" size="5">
                             <?php $percentages = array(); for ($i = 0; $i <= 100; $i += 10) $percentages[$i] = $i; ?>
                             <?php echo tpl_options(array('' => L('anyprogress')) + $percentages, Get::val('percent', '')); ?>
-
                         </select>
                     </div>
                     <div class="clear"></div>
@@ -256,11 +228,8 @@
 		    <?php if (!$filter || in_array('assignedto', $fields)) { ?>
                     <label class="default multisel" for="dev"><?php echo Filters::noXSS(L('assignedto')); ?></label>
                     <?php echo tpl_userselect('dev', Get::val('dev'), 'dev'); } ?>
-
-
                     <label class="default multisel" for="closed"><?php echo Filters::noXSS(L('closedby')); ?></label>
                     <?php echo tpl_userselect('closed', Get::val('closed'), 'closed'); ?>
-
                 </fieldset>
 
                 <fieldset class="advsearch_dates">
@@ -272,37 +241,24 @@
 		    <div style="display:none">
 		    <?php } ?>
                         <?php echo tpl_datepicker('duedatefrom', L('selectduedatefrom')); ?>
-
                         <?php echo tpl_datepicker('duedateto', L('selectduedateto')); ?>
                     </div>
-
                     <div class="dateselect">
                         <?php echo tpl_datepicker('changedfrom', L('selectsincedatefrom')); ?>
-
                         <?php echo tpl_datepicker('changedto', L('selectsincedateto')); ?>
-
                     </div>
-
                     <div class="dateselect">
                         <?php echo tpl_datepicker('openedfrom', L('selectopenedfrom')); ?>
-
                         <?php echo tpl_datepicker('openedto', L('selectopenedto')); ?>
-
                     </div>
-
                     <div class="dateselect">
                         <?php echo tpl_datepicker('closedfrom', L('selectclosedfrom')); ?>
-
                         <?php echo tpl_datepicker('closedto', L('selectclosedto')); ?>
-
                     </div>
                 </fieldset>
-
             </div>
-            <input type="hidden" name="do" value="index"/>
-</form>
-<form action="<?php echo Filters::noXSS($baseurl); ?>/scripts/index.php" method="post">
-<input type='submit' name='export_list' value='<?php echo Filters::noXSS(L('exporttasklist')); ?>'>
+        <input type="hidden" name="do" value="index"/>
+	<input type='submit' name='export_list' value='<?php echo Filters::noXSS(L('exporttasklist')); ?>'>
 </form>
 <?php endif; ?>
 
@@ -324,7 +280,6 @@
         <?php endif; ?>
         <?php foreach ($visible as $col): ?>
         <?php echo tpl_list_heading($col, "<th%s>%s</th>"); ?>
-
         <?php endforeach; ?>
     </tr>
     </thead>
@@ -378,18 +333,18 @@
         <?php endif;?>
 
         <?php foreach ($visible as $col):
-						if($col == 'progress'):?>
-        <td class="task_progress">
+		if($col == 'progress'):?>
+        	<td class="task_progress">
             <div class="progress_bar_container">
                 <span><?php echo Filters::noXSS($task_details['percent_complete']); ?>%</span>
 
                 <div class="progress_bar" style="width:<?php echo Filters::noXSS($task_details['percent_complete']); ?>%"></div>
             </div>
         </td>
-        <?php else: ?>
-        <?php echo tpl_draw_cell($task_details, $col); ?>
-
-        <?php endif; endforeach; ?>
+        	<?php else: ?>
+        	<?php echo tpl_draw_cell($task_details, $col); ?>
+        	<?php endif;
+        endforeach; ?>
 <div id="desc_<?php echo $task_details['task_id']; ?>" class="descbox box">
 <b>Task Description:</b>
 <?php echo $task_details['detailed_desc'] ? $task_details['detailed_desc'] : "<p>No Description</p>"; ?>
@@ -408,17 +363,12 @@
             <?php if (!$proj->id == 0 && !$user->isAnon() && $total){ ?>
             <?php } ?>
         </td>
-        <td id="numbers">
-            <?php echo pagenums($pagenum, $perpage, $total); ?>
-
-        </td>
+        <td id="numbers"><?php echo pagenums($pagenum, $perpage, $total); ?></td>
         <?php else: ?>
         <td id="taskrange"><strong><?php echo Filters::noXSS(L('noresults')); ?></strong></td>
         <?php endif; ?>
     </tr>
 </table>
-
-
 
 <!--- Bulk editing Tasks --->
 <?php if (!$proj->id == 0): ?>
@@ -482,7 +432,6 @@
                 <label for="bulk_tasktype"><?php echo Filters::noXSS(L('tasktype')); ?></label>
                 <select id="bulk_tasktype" name="bulk_task_type">
                     <?php echo tpl_options($taskTypeList); ?>
-
                 </select>
 
             </li>
@@ -498,7 +447,6 @@
                 <label for="bulk_category"><?php echo Filters::noXSS(L('category')); ?></label>
                 <select id="bulk_category" name="bulk_category">
                     <?php echo tpl_options($categoryTypeList); ?>
-
                 </select>
 
             </li>
@@ -535,7 +483,6 @@
                 <label for="bulk_os"><?php echo Filters::noXSS(L('operatingsystem')); ?></label>
                 <select id="bulk_os" name="bulk_os">
                     <?php echo tpl_options($osTypeList); ?>
-
                 </select>
             </li>
 
@@ -550,7 +497,6 @@
                 <label for="bulk_severity"><?php echo Filters::noXSS(L('severity')); ?></label>
                 <select id="bulk_severity" name="bulk_severity">
                     <?php echo tpl_options($severityTypeList); ?>
-
                 </select>
             </li>
 
@@ -566,7 +512,6 @@
                 <label for="bulk_priority"><?php echo Filters::noXSS(L('priority')); ?></label>
                 <select id="bulk_priority" name="bulk_priority">
                     <?php echo tpl_options($priorityTypeList); ?>
-
                 </select>
             </li>
 
@@ -581,7 +526,6 @@
                 <label for="bulk_reportedver"><?php echo Filters::noXSS(L('reportedversion')); ?></label>
                 <select id="bulk_reportedver" name="bulk_reportedver">
                     <?php echo tpl_options($reportedVerList); ?>
-
                 </select>
             </li>
 
@@ -597,7 +541,6 @@
                 <label for="bulk_dueversion"><?php echo Filters::noXSS(L('dueinversion')); ?></label>
                 <select id="bulk_dueversion" name="bulk_due_version">
                     <?php echo tpl_options($dueInVerList); ?>
-
                 </select>
             </li>
 
@@ -609,7 +552,6 @@
                 <?php } ?>
                 <label for="bulk_due_date"><?php echo Filters::noXSS(L('duedate')); ?></label>
                 <?php echo tpl_datepicker('bulk_due_date'); ?>
-
             </li>
 
             <!-- Projects -->
@@ -624,13 +566,11 @@
                 <label for="bulk_projects"><?php echo Filters::noXSS(L('attachedtoproject')); ?></label>
                 <select id="bulk_projects" name="bulk_projects">
                     <?php echo tpl_options($projectsList); ?>
-
                 </select>
             </li>
             </li>
 
         </ul>
-
         <button type="submit" name="updateselectedtasks" value="true"><?php echo Filters::noXSS(L('updateselectedtasks')); ?></button>
     </fieldset>
     <fieldset>
@@ -639,7 +579,6 @@
                 <select class="adminlist" name="resolution_reason" onmouseup="Event.stop(event);">
                     <option value="0"><?php echo Filters::noXSS(L('selectareason')); ?></option>
                     <?php echo tpl_options($proj->listResolutions(), Req::val('resolution_reason')); ?>
-
                 </select>
                 <button type="submit" name="updateselectedtasks" value="false">close tasks</button>
                 <br/>
@@ -648,7 +587,7 @@
                           cols="25"><?php echo Filters::noXSS(Req::val('closure_comment')); ?></textarea>
                 <label><?php echo tpl_checkbox('mark100', Req::val('mark100', !(Req::val('action') == 'details.close'))); ?>&nbsp;&nbsp;<?php echo Filters::noXSS(L('mark100')); ?></label>
             </div>
-    </fiedlset>
+    </fieldset>
 
 </div>
 

--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -81,8 +81,6 @@
 <label id="searchstateactions" class="button main" for="s_searchstate"><?php echo Filters::noXSS(L('advanced')); ?></label>
 <div id="sc2" class="switchcontent">
 <?php if (!$user->isAnon()): ?>
-<div id="sc2" class="switchcontent">
-<?php if (!$user->isAnon()): ?>
 <fieldset>
   <div class="save_search"><label for="save_search" id="lblsaveas"><?php echo Filters::noXSS(L('saveas'));?></label>
    <input class="text" type="text" value="<?php echo Filters::noXSS(Get::val('search_name')); ?>" id="save_search" name="search_name" size="15"/> <button onclick="savesearch('<?php echo Filters::escapeqs($_SERVER['QUERY_STRING']); ?>', '<?php echo Filters::noJsXSS($baseurl); ?>', '<?php echo Filters::noXSS(L('saving')); ?>')" type="button"><?php echo Filters::noXSS(L('OK')); ?></button>

--- a/themes/CleanFS/templates/newmultitasks.tpl
+++ b/themes/CleanFS/templates/newmultitasks.tpl
@@ -14,7 +14,7 @@
     3. There are suggestions when you assign to someone, and to no-one if there is no matched name.
 
 </div>
-<form enctype="multipart/form-data" action="<?php echo Filters::noXSS(CreateUrl('newmultitasks', $proj->id, $supertask_id)); ?>" method="post">
+<?php echo tpl_form(Filters::noXSS(CreateUrl('newmultitasks', $proj->id, $supertask_id))); ?>
   <input type="hidden" name="supertask_id" value="<?php echo Filters::noXSS($supertask_id); ?>" />
   <input type="hidden" name="action" value="newmultitasks.newmultitasks" />
 

--- a/themes/CleanFS/templates/newtask.tpl
+++ b/themes/CleanFS/templates/newtask.tpl
@@ -30,7 +30,8 @@
 		return false;
 	}
   </script>
-<form enctype="multipart/form-data" action="<?php echo Filters::noXSS(CreateUrl('newtask', $proj->id, $supertask_id)); ?>" method="post" onsubmit="return checkContent()">
+<!-- <form enctype="multipart/form-data" action="<?php echo Filters::noXSS(CreateUrl('newtask', $proj->id, $supertask_id)); ?>" method="post" onsubmit="return checkContent()"> -->
+<?php echo tpl_form(Filters::noXSS(CreateUrl('newtask', $proj->id, $supertask_id)), 'newtask', 'post', 'multipart/form-data', 'onsubmit="return checkContent()"'); ?>
   <input type="hidden" name="supertask_id" value="<?php echo Filters::noXSS($supertask_id); ?>" />
   <div id="actionbar">
 

--- a/themes/CleanFS/templates/pm.prefs.tpl
+++ b/themes/CleanFS/templates/pm.prefs.tpl
@@ -1,7 +1,7 @@
 <div id="toolbox">
   <h3><?php echo Filters::noXSS($proj->prefs['project_title']); ?> : <?php echo Filters::noXSS(L('preferences')); ?></h3>
 
-  <form action="<?php echo Filters::noXSS(CreateUrl('pm', 'prefs', $proj->id)); ?>" method="post">
+  <?php echo tpl_form(CreateUrl('pm', 'prefs', $proj->id)); ?>
   <ul id="submenu">
    <li><a href="#general"><?php echo Filters::noXSS(L('general')); ?></a></li>
    <li><a href="#lookandfeel"><?php echo Filters::noXSS(L('lookandfeel')); ?></a></li>

--- a/themes/CleanFS/templates/profile.tpl
+++ b/themes/CleanFS/templates/profile.tpl
@@ -1,12 +1,8 @@
 <fieldset class="box"><legend><?php echo Filters::noXSS(L('profile')); ?> <?php echo Filters::noXSS($theuser->infos['real_name']); ?> (<?php echo Filters::noXSS($theuser->infos['user_name']); ?>)</legend>
-
 <table id="profile">
   <tr>
     <th><?php echo Filters::noXSS(L('realname')); ?></th>
-    <td>
-      <?php echo Filters::noXSS($theuser->infos['real_name']); ?>
-
-    </td>
+    <td><?php echo Filters::noXSS($theuser->infos['real_name']); ?></td>
   </tr>
   <tr>
   <?php if ((!$user->isAnon() && !$fs->prefs['hide_emails'] && !$theuser->infos['hide_my_email']) || $user->perms('is_admin')): ?>
@@ -18,43 +14,33 @@
   <?php endif; ?>
   <tr>
     <th><?php echo Filters::noXSS(L('jabberid')); ?></th>
-    <td>
-      <?php echo Filters::noXSS($theuser->infos['jabber_id']); ?>
-
-    </td>
+    <td><?php echo Filters::noXSS($theuser->infos['jabber_id']); ?></td>
   </tr>
   <tr>
     <th><?php echo Filters::noXSS(L('globalgroup')); ?></th>
-    <td>
-      <?php echo Filters::noXSS($groups[Flyspray::array_find('group_id', $theuser->infos['global_group'], $groups)]['group_name']); ?>
-
-    </td>
+    <td><?php echo Filters::noXSS($groups[Flyspray::array_find('group_id', $theuser->infos['global_group'], $groups)]['group_name']); ?></td>
   </tr>
   <?php if ($proj->id): ?>
   <tr>
     <th><?php echo Filters::noXSS(L('projectgroup')); ?></th>
     <td>
     <?php if ($user->perms('manage_project')): ?>
-    <form method="post" action="<?php echo Filters::noXSS($baseurl); ?>index.php?do=user&amp;id=<?php echo Filters::noXSS($theuser->id); ?>"><div>
+    <?php echo tpl_form(Filters::noXSS($baseurl).'index.php?do=user&amp;id='.Filters::noXSS($theuser->id)); ?>
       <select id="projectgroupin" class="adminlist" name="project_group_in">
         <?php $sel = $theuser->perms('project_group') == '' ? 0 : $theuser->perms('project_group'); ?>
         <?php echo tpl_options(array_merge($project_groups, array(0 => array('group_name' => L('none'), 0 => 0, 'group_id' => 0, 1 => L('none')))), $sel); ?>
-
       </select>
       <input type="hidden" name="old_project_id" value="<?php echo Filters::noXSS($theuser->perms('project_group')); ?>" />
       <input type="hidden" name="action" value="admin.edituser" />
       <input type="hidden" name="user_id" value="<?php echo Filters::noXSS($theuser->id); ?>" />
       <input type="hidden" name="onlypmgroup" value="1" />
-
       <button type="submit"><?php echo Filters::noXSS(L('update')); ?></button>
-    </div></form>
+    </form>
     <?php else: ?>
       <?php if ($theuser->perms('project_group')): ?>
       <?php echo Filters::noXSS($project_groups[Flyspray::array_find('group_id', $theuser->perms('project_group'), $project_groups)]['group_name']); ?>
-
       <?php else: ?>
       <?php echo Filters::noXSS(L('none')); ?>
-
       <?php endif; ?>
     <?php endif; ?>
     </td>
@@ -62,34 +48,21 @@
   <?php endif; ?>
   <tr>
     <th><a href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?opened=<?php echo Filters::noXSS($theuser->id); ?>&amp;status[]="><?php echo Filters::noXSS(L('tasksopened')); ?></a></th>
-    <td>
-      <?php echo Filters::noXSS($tasks); ?>
-
-    </td>
+    <td><?php echo Filters::noXSS($tasks); ?></td>
   </tr>
   <tr>
     <th><a href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?dev=<?php echo Filters::noXSS($theuser->id); ?>"><?php echo Filters::noXSS(L('assignedto')); ?></a></th>
-    <td>
-      <?php echo Filters::noXSS($assigned); ?>
-
-    </td>
+    <td><?php echo Filters::noXSS($assigned); ?></td>
   </tr>
   <tr>
     <th><?php echo Filters::noXSS(L('comments')); ?></th>
-    <td>
-      <?php echo Filters::noXSS($comments); ?>
-
-    </td>
+    <td><?php echo Filters::noXSS($comments); ?></td>
   </tr>
   <?php if ($theuser->infos['register_date']): ?>
   <tr>
     <th><?php echo Filters::noXSS(L('regdate')); ?></th>
-    <td>
-      <?php echo Filters::noXSS(formatDate($theuser->infos['register_date'])); ?>
-
-    </td>
+    <td><?php echo Filters::noXSS(formatDate($theuser->infos['register_date'])); ?></td>
   </tr>
   <?php endif; ?>
 </table>
-
 </fieldset>

--- a/themes/CleanFS/templates/register.magic.tpl
+++ b/themes/CleanFS/templates/register.magic.tpl
@@ -1,7 +1,6 @@
 <h3><?php echo Filters::noXSS(L('registernewuser')); ?></h3>
 <div class="box">
-  
-<form action="<?php echo Filters::noXSS($baseurl); ?>index.php" name="registernewuser" method="post" id="registernewuser">
+<?php echo tpl_form(Filters::noXSS($baseurl).'index.php','registernewuser',null,null,'id="registernewuser"'); ?>  
   <p><?php echo Filters::noXSS(L('entercode')); ?></p>
   <ul class="form_elements wide">
     <li>
@@ -19,12 +18,10 @@
       <input id="user_pass2" class="password" name="user_pass2" value="<?php echo Filters::noXSS(Req::val('user_pass2')); ?>" type="password" size="20" maxlength="100" />
     </li>
   </ul>
-
-    <div>
-        <input type="hidden" name="action" value="register.registeruser" />
-        <input type="hidden" name="magic_url" value="<?php echo Filters::noXSS(Req::val('magic_url')); ?>" />
-        <button type="submit" name="buSubmit"><?php echo Filters::noXSS(L('registeraccount')); ?></button>
-    </div>
+  <div>
+    <input type="hidden" name="action" value="register.registeruser" />
+    <input type="hidden" name="magic_url" value="<?php echo Filters::noXSS(Req::val('magic_url')); ?>" />
+    <button type="submit" name="buSubmit"><?php echo Filters::noXSS(L('registeraccount')); ?></button>
+  </div>
 </form>
-
 </div>

--- a/themes/CleanFS/templates/register.no-magic.tpl
+++ b/themes/CleanFS/templates/register.no-magic.tpl
@@ -1,7 +1,6 @@
 <h3><?php echo Filters::noXSS(L('registernewuser')); ?></h3>
 <div class="box">
-
-<form action="<?php echo Filters::noXSS(CreateUrl('register')); ?>" method="post" id="registernewuser">
+<?php echo tpl_form(Filters::noXSS(CreateUrl('register')),null,null,null,'id="registernewuser"'); ?>
 	<ul class="form_elements wide">
 		<li>
 			<label for="username"><?php echo Filters::noXSS(L('username')); ?></label>

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -1530,24 +1530,22 @@ div#closeform {
     list-style: none;
 }
 #actionsform li {
-    display: block;
-    position: relative;
-    background: #363a3b;
-    color:#fff;
-    padding: 5px 15px 5px 15px;
+	border-top: 1px solid #fff;
+	display: block;
+	position: relative;
+	background: #363a3b;
+	color:#fff;
+	padding: 5px 15px;
 }
 #actionsform li ul { display: none; }
 #actionsform ul li a {
     display: block;
     text-decoration: none;
     color: #fff;
-    border-top: 1px solid #fff;
-    padding: 5px 15px 5px 15px;
-    background: #363a3b;
     margin-left: 1px;
     white-space: nowrap;
 }
-#actionsform ul li a:hover { background: #617F8A; }
+#actionsform ul li:hover { background: #617F8A; }
 #actionsform li:hover ul {
     display: block;
     position: absolute;

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -512,8 +512,6 @@ body.toplevel .box {
   border-radius: 3px;
   margin: 10px 0 0 10px;
   width: 400px;
-  height: 275px;
-  /*height: 280px;*/
   /*@include inline-block;*/
   /*vertical-align: middle;*/
   float: left; }

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -1535,17 +1535,17 @@ div#closeform {
 	position: relative;
 	background: #363a3b;
 	color:#fff;
-	padding: 5px 15px;
+	padding: 0px;
 }
-#actionsform li ul { display: none; }
-#actionsform ul li a {
+#actionsform li a, #actionsform li label{
     display: block;
     text-decoration: none;
     color: #fff;
-    margin-left: 1px;
     white-space: nowrap;
+    padding:5px 15px;
 }
 #actionsform ul li:hover { background: #617F8A; }
+#actionsform li:hover ul {display:none;}
 #actionsform li:hover ul {
     display: block;
     position: absolute;
@@ -1554,28 +1554,20 @@ div#closeform {
     float: none;
     font-size: 11px;
 }
-#actionsform li:hover a { background: #617F8A; }
-#actionsform li:hover li a:hover { background: #95A9B1; }
 
-#setparentform{
+#setparentform, #associateform,#adddepform {
 	display:none;
 	background: #363a3b;
 	color:#fff;
 	padding-left: 5px;
 }
-#s_parent{display:none;}
-#s_parent:checked ~ #setparentform{display:block;}
-
-#associateform{
-    background: #363a3b;
-    color:#ffffff;
-    padding-left: 5px;
+#s_parent, #s_associate, #s_adddependent {
+	display:none;
 }
-
-#adddepform{
-    background: #363a3b;
-    color:#ffffff;
-    padding-left: 5px;
+#s_parent:checked ~ #setparentform,
+#s_associate:checked ~ #associateform,
+#s_adddependent:checked ~ #adddepform{
+	display:block;
 }
 
 #taskdeps h4 {

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -1507,7 +1507,7 @@ div#closeform {
   right: 5px;
   top: 3em; }
 
-div#actionsform {
+#actionsform {
     border-radius: 3px;
     -moz-border-radius: 3px;
     -webkit-border-radius: 3px;
@@ -1522,83 +1522,75 @@ div#actionsform {
     z-index: 500;
 }
 
-div#actionsform ul {
+#actionsform ul {
     font-family: Arial, Verdana;
     font-size: 12px;
     margin: 0;
     padding: 0;
     list-style: none;
 }
-div#actionsform ul li {
+#actionsform ul li {
     display: block;
     position: relative;
-
+    background: #363a3b;
 }
-div#actionsform li ul { display: none; }
-div#actionsform ul li a {
+#actionsform li ul { display: none; }
+#actionsform ul li a {
     display: block;
     text-decoration: none;
-    color: #ffffff;
-    border-top: 1px solid #ffffff;
+    color: #fff;
+    border-top: 1px solid #fff;
     padding: 5px 15px 5px 15px;
     background: #363a3b;
     margin-left: 1px;
     white-space: nowrap;
 }
-div#actionsform ul li a:hover { background: #617F8A; }
-div#actionsform li:hover ul {
+#actionsform ul li a:hover { background: #617F8A; }
+#actionsform li:hover ul {
     display: block;
     position: absolute;
 }
-div#actionsform li:hover li {
+#actionsform li:hover li {
     float: none;
     font-size: 11px;
 }
-div#actionsform li:hover a { background: #617F8A; }
-div#actionsform li:hover li a:hover { background: #95A9B1; }
+#actionsform li:hover a { background: #617F8A; }
+#actionsform li:hover li a:hover { background: #95A9B1; }
 
-
-div#actionsform button{
-    position:absolute;
-    right: 5px;
+#setparentform{
+	display:none;
+	background: #363a3b;
+	color:#fff;
+	padding-left: 5px;
 }
+#s_parent{display:none;}
+#s_parent:checked ~ #setparentform{display:block;}
 
-div#actionsform input{
-    position:absolute;
-    right: 50px;
-}
-
-div#setparentform{
+#associateform{
     background: #363a3b;
     color:#ffffff;
     padding-left: 5px;
 }
 
-div#associateform{
+#adddepform{
     background: #363a3b;
     color:#ffffff;
     padding-left: 5px;
 }
 
-div#adddepform{
-    background: #363a3b;
-    color:#ffffff;
-    padding-left: 5px;
-}
-
-div#taskdeps h4 {
+#taskdeps h4 {
   margin-bottom:0.3em;
 }
 
-div#taskdeps table {
+#taskdeps table {
   margin:0 0 0.8em -0.2em;
 }
 
-div#taskdeps td {
+#taskdeps td {
   padding:0.2em 0.4em;
 }
 
-div#taskdeps img {
+#taskdeps img {
   vertical-align:middle;
   margin-top:-1px;
 }

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -1529,10 +1529,12 @@ div#closeform {
     padding: 0;
     list-style: none;
 }
-#actionsform ul li {
+#actionsform li {
     display: block;
     position: relative;
     background: #363a3b;
+    color:#fff;
+    padding: 5px 15px 5px 15px;
 }
 #actionsform li ul { display: none; }
 #actionsform ul li a {

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -1303,15 +1303,14 @@ fieldset.advsearch_dates label {
   position: relative;
   margin-right: 10px; }
 
-  .search_select .multisel {
+.search_select .multisel {
     position: absolute;
-    white-space: nowrap; }
+    white-space: nowrap;
 
-  .search_select select {
+}
+.search_select select {
     margin-top: 1.3em;
-    height: 7em; }
-
-
+}
 fieldset.advsearch_users .multisel {
   position: absolute;
   white-space: nowrap; }
@@ -1608,11 +1607,12 @@ input[type=text], input[type=password], select {
     color: #000;
     background: #fff;
     border: 1px solid #ccc;
-    height: 19px;
     padding: 2px;
     vertical-align: middle;
 }
-
+input[type=text], input[type=password]{
+    height: 19px;
+}
 #table input[type=text] {
     width: 120px;
 }
@@ -1635,7 +1635,6 @@ input[type=text], input[type=submit], button, select {
 }
 
 button {vertical-align: middle; margin-bottom: 2px; line-height: 20px;}
-select {height: 23px; vertical-align: middle;}
 
 input[type=submit]:hover, button:hover {
     background: #5F9729;


### PR DESCRIPTION
Maybe a handful of actions still must be makeover for anti csrf token.

Please don't be too upset if some buttons now look a bit ugly, but that was needed to replace simple links by a form. 

This can all be fixed by CSS.

Due some cookies are dropped in favor of urlparams for handling parallel different projects in different browser tabs, the are still some usability issues like the jump to default project when you hit the flyspray icon/project heading.
