### PR TITLE
Misc small fixes

### DIFF
--- a/lang/en.php
+++ b/lang/en.php
@@ -946,7 +946,8 @@ Regards,',
 'exporttasklist'          => 'Export Tasklist',
 'manday'                  => 'man-day',
 'mandays'                 => 'may-days',
-'itemexists'              => 'Item already exists in database.',
+'itemexists'              => 'Item %s already exists in database.',
+'categoryitemexists'      => 'Item %s already exists under category %s in database.',
 'pageswelcomemsg'         => 'Pages where to show main intro message',
 'pagesintromsg'           => 'Pages where to show intro message'
 );

--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -765,54 +765,6 @@ function quick_edit(elem, id)
             </tbody>
         </table>
         <?php endif; ?>
-        <!-- This task blocks the following tasks: -->
-        <?php if(!count($blocks)==0): ?>
-        <?php $projects = $fs->listProjects(); ?>
-        <table id="blocking_table" class="table" width="100%">
-            <!-- <caption>This task prevents closing the following tasks.</caption> -->
-            <caption><?php echo Filters::noXSS(L('taskblocks')); ?></caption>
-            <thead>
-            <tr>
-                <th><?php echo Filters::noXSS(L('id')); ?></th>
-                <th><?php echo Filters::noXSS(L('project')); ?></th>
-                <th><?php echo Filters::noXSS(L('summary')); ?></th>
-                <th><?php echo Filters::noXSS(L('priority')); ?></th>
-                <th><?php echo Filters::noXSS(L('severity')); ?></th>
-                <th><?php echo Filters::noXSS(L('progress')); ?></th>
-                <!-- <th><?php echo Filters::noXSS(L('assignedto')); ?></th> -->
-                <th></th>
-            </tr>
-            </thead>
-            <tbody>
-            <?php foreach ($blocks as $dependency): ?>
-            <tr>
-                <td><?php echo $dependency['task_id'] ?></td>
-                <td><?php echo $dependency['project_title'] ?></td>
-                <td><?php echo tpl_tasklink($dependency['task_id']); ?></td>
-                <td><?php echo $fs->priorities[$dependency['task_priority']] ?></td>
-                <td class="severity<?php echo Filters::noXSS($dependency['task_severity']); ?>"><?php echo $fs->
-                    severities[$dependency['task_severity']] ?>
-                </td>
-                <td class="task_progress">
-                    <div class="progress_bar_container">
-                        <span><?php echo Filters::noXSS($dependency['percent_complete']); ?>%</span>
-
-                        <div class="progress_bar" style="width:<?php echo Filters::noXSS($dependency['percent_complete']); ?>%"></div>
-                    </div>
-                </td>
-                <!-- <td>Assignees TODO</td> -->
-                <td>
-                    <a class="removedeplink"
-                       href="<?php echo Filters::noXSS($_SERVER['SCRIPT_NAME']); ?>?do=details&amp;action=removedep&amp;depend_id=<?php echo Filters::noXSS($dependency['depend_id']); ?>&amp;task_id=<?php echo Filters::noXSS($dependency['task_id']); ?>&amp;return_task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>">
-                        <img src="<?php echo Filters::noXSS($this->get_image('button_cancel')); ?>" alt="<?php echo Filters::noXSS(L('remove')); ?>" title="<?php echo Filters::noXSS(L('remove')); ?>"/>
-                    </a>
-                </td>
-            </tr>
-            <?php endforeach; ?>
-            </tbody>
-        </table>
-        <?php endif; ?>
-        <!-- End blocking tasks. -->
         
         <?php
             if (!$task_details['supertask_id']==0)


### PR DESCRIPTION
- Removed accidentally duplicated "This task blocks these from closing".
- Enhanced error messages.
- Added duplicate checks for category entries too.

Note that when fixing possibly already existing duplicate entries, like having "Report 1" twice on the same level and under same category, the fixing must be done in 2 phases.

First phase:
Report 1 -> Report 1 (rename back later)
Report 1 -> Report 2

Second phase:
Report 1 (rename back later) -> Report 1

Reason: if the first Report 1 is not renamed in the first phase, the second Report 1 has not been yet updated to a new value when first one is checked for duplicates and so will be considered a duplicate entry.