### PR TITLE
Prevent "Undefined index: whatevervalue in scripts\index.php on line 229"

### DIFF
--- a/scripts/index.php
+++ b/scripts/index.php
@@ -226,8 +226,22 @@ function tpl_draw_cell($task, $colname, $format = "<td class='%s'>%s</td>") {
             break;
 		
         default:
+            $value = '';
+            // $colname here is NOT column name in database but a name that can appear
+            // both in a projects visible fields and as a key in language translation
+            // file, which is also used to draw a localized heading. Column names in
+            // database customarily use _ t to separate words, translation file entries
+            // instead do not and can be also be quite different. If you do see an empty
+            // value when you expected something, check your usage, what visible fields
+            // in database actually constains, and maybe add a mapping from $colname to
+            // to the database column name to array $indexes at the beginning of this
+            // function. Note that inconsistencies between $colname, database column
+            // name, translation entry key and name in visible fields do occur sometimes
+            // during development phase.
+            if (array_key_exists($colname, $indexes)) {
         	$value = htmlspecialchars($task[$indexes[$colname]], ENT_QUOTES, 'utf-8');
-        	break;
+            }
+            break;
 	}
 	return sprintf($format, 'task_'.$colname, $value);
 }

--- a/themes/CleanFS/templates/admin.prefs.tpl
+++ b/themes/CleanFS/templates/admin.prefs.tpl
@@ -294,10 +294,16 @@
           <li>
             <label><?php echo Filters::noXSS(L('visiblecolumns')); ?></label>
             <?php // Set the selectable column names
+            // Do NOT use real database column name here and in the next list,
+            // but a term from translation table entries instead, because it's
+            // also used elsewhere to draw a localized version of the name,
+            // and with some extra work, this list too might show localized
+            // names in a future version. Look also at the end of function
+            // tpl_draw_cell in scripts/index.php for further explanation.
             $columnnames = array('id', 'parent', 'project', 'tasktype', 'category', 'severity',
             'priority', 'summary', 'dateopened', 'status', 'openedby', 'private',
             'assignedto', 'lastedit', 'reportedin', 'dueversion', 'duedate',
-            'comments', 'attachments', 'progress', 'dateclosed', 'os', 'votes','estimated_effort','effort');
+            'comments', 'attachments', 'progress', 'dateclosed', 'os', 'votes','estimatedeffort','effort');
             $selectedcolumns = explode(" ", $fs->prefs['visible_columns']);
             ?>
             <?php echo tpl_double_select('visible_columns', $columnnames, $selectedcolumns, true); ?>

--- a/themes/CleanFS/templates/pm.prefs.tpl
+++ b/themes/CleanFS/templates/pm.prefs.tpl
@@ -140,6 +140,12 @@
         <li>
           <label><?php echo Filters::noXSS(L('visiblecolumns')); ?></label>
           <?php // Set the selectable column names
+          // Do NOT use real database column name here and in the next list,
+          // but a term from translation table entries instead, because it's
+          // also used elsewhere to draw a localized version of the name,
+          // and with some extra work, this list too might show localized
+          // names in a future version. Look also at the end of function
+          // tpl_draw_cell in scripts/index.php for further explanation.
           $columnnames = array('id', 'parent', 'tasktype', 'category', 'severity',
           'priority', 'summary', 'dateopened', 'status', 'openedby', 'private',
           'assignedto', 'lastedit', 'reportedin', 'dueversion', 'duedate',


### PR DESCRIPTION
Prevent "Undefined index: whatevervalue in scripts\index.php on line 229" ever occuring once more and wrote a long explanation about what's really happening, so nobody's going cause the same kind of mess again.