### PR TITLE
allow some more html tags that should be ok

### DIFF
--- a/includes/class.tpl.php
+++ b/includes/class.tpl.php
@@ -600,7 +600,7 @@ class TextFormatter
             return call_user_func(array($conf['general']['syntax_plugin'] . '_TextFormatter', 'render'),
                                   $text, $type, $id, $instructions);
         } else {
-            $text=strip_tags($text, '<br><br/><p><blockquote><a><ul><ol><li>');
+            $text=strip_tags($text, '<br><br/><p><h2><h3><h4><h5><h5><h6><blockquote><a><img><u><b><strong><s><ins><del><ul><ol><li>');
             $text.='Missing output plugin '.$conf['general']['syntax_plugin'].'!'
               .'<br/>Couldn\'t call '.$conf['general']['syntax_plugin'].'_TextFormatter::render()'
               .'<br/>Temporarly handled like it is HTML until fixed<br/>'


### PR DESCRIPTION
I'm quite sure 

    <h1> tag

shouldn't be allowed because this is at least reserved for the task title and there is also a h1-tag on the flyspray website...

Maybe also disallow h2-tag ?
 
So 
h1 = website heading
h2 = a task heading
h3,h4,h5,h6 = custom headings allowed in the task description