### PR TITLE
Only use html entities for those 5 well-known characters

### DIFF
--- a/includes/class.tpl.php
+++ b/includes/class.tpl.php
@@ -639,7 +639,7 @@ class TextFormatter
 
         //Activate CkEditor on TextAreas.
         $return .= "<script>
-                        CKEDITOR.replace( '".$name."' );
+                        CKEDITOR.replace( '".$name."', { entities: true, entities_latin: false, entities_processNumerical: false } );
                     </script>";
         return $return;
     }


### PR DESCRIPTION
 when posting data, not for letters used for writing ordinary text. Breaks some searches.