### PR TITLE
Storing jabber_id as '' instead of '0' if not given.

### DIFF
--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -1196,7 +1196,7 @@ switch ($action = Req::val('action'))
                             hide_my_email = ?, notify_online = ?
                      WHERE  user_id = ?',
                 array(Post::val('real_name'), Post::val('email_address'), Post::num('notify_own', 0),
-                    Post::val('jabber_id', 0), Post::num('notify_type'),
+                    Post::val('jabber_id', ''), Post::num('notify_type'),
                     Post::val('dateformat', 0), Post::val('dateformat_extended', 0),
                     Post::num('tasks_perpage'), Post::num('time_zone'), Post::val('lang_code', 'en'),
                     Post::num('hide_my_email', 0), Post::num('notify_online', 0), Post::num('user_id')));


### PR DESCRIPTION
Storing jabber_id as '0' instead of '' doesn't play nice with notifications.