### PR TITLE
fix register output

### DIFF
--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -641,7 +641,6 @@ switch ($action = Req::val('action'))
 
         $_SESSION['SUCCESS'] = L('accountcreated');
         define('NO_DO', true);
-        $page->pushTpl('register.ok.tpl');
         break;
 
         // ##################
@@ -734,7 +733,6 @@ switch ($action = Req::val('action'))
 
         if (!$user->perms('is_admin')) {
             define('NO_DO', true);
-            $page->pushTpl('register.ok.tpl');
         }
         break;
 
@@ -797,7 +795,6 @@ switch ($action = Req::val('action'))
             $_SESSION['SUCCESS'] = L('created').$success;
             if (!$user->perms('is_admin')) {
                 define('NO_DO', true);
-                $page->pushTpl('register.ok.tpl');
             }
         }
         break;

--- a/index.php
+++ b/index.php
@@ -180,8 +180,10 @@ $page->pushTpl('header.tpl');
 
 if (!defined('NO_DO')) {
     require_once(BASEDIR . "/scripts/$do.php");
+} else{
+    # not nicest solution, NO_DO currently only used on register actions 
+    $page->pushTpl('register.ok.tpl');
 }
-
 $page->pushTpl('footer.tpl');
 $page->setTheme($proj->prefs['theme_style']);
 $page->render();


### PR DESCRIPTION
the register.ok.tpl template should be set at page content position, not output itself before page headings.