### PR TITLE
fix FS#1841

### DIFF
--- a/themes/CleanFS/templates/reports.tpl
+++ b/themes/CleanFS/templates/reports.tpl
@@ -49,7 +49,7 @@ if(isset($theuser->infos['eventtypes'])){
 
     <?php if ($histories): ?>
     <div id="tasklist">
-    <table id="tasklist_table">
+    <table id="eventlist_table">
      <thead>
       <tr>
         <th>


### PR DESCRIPTION
The reason was a javascript loaded on this page, that autolinks to the task of the clicked row. well on user  account related events there is not task id..

I think this script can be replaced by html only.

But for this bugfix we simply change the id of the eventlog html table.