### PR TITLE
#Discuss it - probably unneeded exit in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -104,7 +104,8 @@ $page = new FSTpl();
 // make sure people are not attempting to manually fiddle with projects they are not allowed to play with
 if (Req::has('project') && Req::val('project') != 0 && !$user->can_view_project(Req::val('project'))) {
     Flyspray::show_error( L('nopermission') );
-    exit;
+// this exit prevents users from access to login box
+//    exit;
 }
 
 if ($show_task = Get::val('show_task')) {


### PR DESCRIPTION
If user sends to someone other URL from the browser, this exit prevets the user to use the URL and login to Flyspray, because only white page is displayed.