### PR TITLE
submit button for the jsless peoples

### DIFF
--- a/themes/CleanFS/templates/links.tpl
+++ b/themes/CleanFS/templates/links.tpl
@@ -116,7 +116,7 @@ endif; ?>
 				<select name="project" onchange="document.getElementById('projectselectorform').submit()">
 				<?php echo tpl_options(array_merge(array(0 => L('allprojects')), $fs->projects), $proj->id); ?>
 				</select>
-				<!--<button type="submit"><?php echo Filters::noXSS(L('switch')); ?></button>-->
+				<noscript><button type="submit"><?php echo Filters::noXSS(L('switch')); ?></button></noscript>
 				<input type="hidden" name="do" value="<?php echo Filters::noXSS($do); ?>" />
 				<input type="hidden" value="1" name="switch" />
 				<?php $check = array('area', 'id');
@@ -133,7 +133,7 @@ endif; ?>
 		</div>
 		<div id="showtask">
 			<form action="<?php echo Filters::noXSS($baseurl); ?>index.php" method="get">
-				<!--<button type="submit"><?php echo Filters::noXSS(L('showtask')); ?> #</button>-->
+				<noscript><button type="submit"><?php echo Filters::noXSS(L('showtask')); ?> #</button></noscript>
 				<input id="task_id" name="show_task" class="text" type="text" size="10" accesskey="t" placeholder="<?php echo Filters::noXSS(L('showtask')); ?> #" />
 			</form>
 		</div>


### PR DESCRIPTION
The second button for the task search is optional even for the jsless peoples, but made them visible for them.
Think of touch displays...
Hope psycho can live with that.

Without the buttons for jsenabled users the select and quick task search fields now looks like one form, but they are completely different forms ...