### PR TITLE
php executable for shell_exec

### DIFF
--- a/setup/composerit2.php
+++ b/setup/composerit2.php
@@ -45,7 +45,11 @@ header("Pragma: no-cache");
 			# echo '</pre>';
 
 			# without chdir('..');
-			$cmd2 = 'php composer.phar --working-dir=.. install';
+			$phpexe='php';
+			# TODO: autodetect the matching commandline php on the host matching the php version of the webserver
+			# This is just a demo for installing flyspray within xampp on Windows, installed on drive d:
+			$phpexe='d:/xampp/php/php.exe';
+			$cmd2 = $phpexe.' composer.phar --working-dir=.. install';
 
 			# with chdir('..');
 			#$cmd2 = 'php composer.phar install';

--- a/setup/composerit2.php
+++ b/setup/composerit2.php
@@ -47,8 +47,9 @@ header("Pragma: no-cache");
 			# without chdir('..');
 			$phpexe='php';
 			# TODO: autodetect the matching commandline php on the host matching the php version of the webserver
+			# Any idea? Using $_SERVER['PHP_PEAR_SYSCONF_DIR'] or $_SERVER['PHPRC'] for detecting can help a bit, but weak hints.. 
 			# This is just a demo for installing flyspray within xampp on Windows, installed on drive d:
-			$phpexe='d:/xampp/php/php.exe';
+			#$phpexe='d:/xampp/php/php.exe';
 			$cmd2 = $phpexe.' composer.phar --working-dir=.. install';
 
 			# with chdir('..');


### PR DESCRIPTION
This is still an open question if php is not in the path when calling shell_exec

And the php on the commandline should be nearly the same version as the php the web server uses.
for example apache uses mod_php, but for shell_exec we need an executable.

All that is in status "researching" ..

And I know, its all a hack to enable the installation over web browser...