### PR TITLE
was a bit too strict on global tag stripping

### DIFF
--- a/includes/class.tpl.php
+++ b/includes/class.tpl.php
@@ -661,7 +661,7 @@ class TextFormatter
             return call_user_func(array($conf['general']['syntax_plugin'] . '_TextFormatter', 'render'),
                                   $text, $type, $id, $instructions);
         } else {
-            $text=strip_tags($text, '<br><br/><p><h2><h3><h4><h5><h5><h6><blockquote><a><img><u><b><strong><s><ins><del><ul><ol><li>');
+            $text=strip_tags($text, '<br><br/><p><h2><h3><h4><h5><h5><h6><blockquote><a><img><u><b><strong><s><ins><del><ul><ol><li><table><caption><tr><col><colgroup><td><th><thead><tfoot><tbody>');
             if ($conf['general']['syntax_plugin'] && $conf['general']['syntax_plugin'] != 'none') {
                 $text='Missing output plugin '.$conf['general']['syntax_plugin'].'!'
                 .'<br/>Couldn\'t call '.$conf['general']['syntax_plugin'].'_TextFormatter::render()'


### PR DESCRIPTION
the default ckeditor allows to construct html tables, so the table tags shouldn't be stripped here.