### PR TITLE
ignore '.' files as directory in listThemes()

### DIFF
--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -29,7 +29,7 @@ class Flyspray
      * @access public
      * @var array
      */
-    public $prefs   = array();
+    public $prefs = array();
 
     /**
      * Max. file size for file uploads. 0 = no uploads allowed
@@ -408,19 +408,19 @@ class Flyspray
      */
     public static function listThemes()
     {
-        $theme_array = array();
+        $themes = array();
         $dirname = dirname(dirname(__FILE__));
         if ($handle = opendir($dirname . '/themes/')) {
             while (false !== ($file = readdir($handle))) {
                 if (substr($file,0,1) != '.' && is_dir("$dirname/themes/$file") && is_file("$dirname/themes/$file/theme.css")) {
-                    $theme_array[] = $file;
+                    $themes[] = $file;
                 }
             }
             closedir($handle);
         }
 
-        sort($theme_array);
-        return $theme_array;
+        sort($themes);
+        return $themes;
     } // }}}
     // List a project's group {{{
     /**

--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -409,9 +409,10 @@ class Flyspray
     public static function listThemes()
     {
         $theme_array = array();
-        if ($handle = opendir(dirname(dirname(__FILE__)) . '/themes/')) {
+        $dirname = dirname(dirname(__FILE__));
+        if ($handle = opendir($dirname . '/themes/')) {
             while (false !== ($file = readdir($handle))) {
-                if ($file != '.' && $file != '..' && is_file(dirname(dirname(__FILE__)) . "/themes/$file/theme.css")) {
+                if (substr($file,0,1) != '.' && is_dir("$dirname/themes/$file") && is_file("$dirname/themes/$file/theme.css")) {
                     $theme_array[] = $file;
                 }
             }


### PR DESCRIPTION
now any file or directory starting with a '.' is ignored as possible theme directory
fixes warnings from is_file(), is_dir() who are probably bugs in PHP itself.

see for example https://bugs.php.net/bug.php?id=69240

thx to mouts
