### PR TITLE
avoid the warning "open_basedir restriction in effect"

### DIFF
--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -412,7 +412,7 @@ class Flyspray
         $dirname = dirname(dirname(__FILE__));
         if ($handle = opendir($dirname . '/themes/')) {
             while (false !== ($file = readdir($handle))) {
-                if ($file != '.' && $file != '..' && is_dir("$dirname/themes/$file") && is_file("$dirname/themes/$file/theme.css")) {
+                if (substr($file, 0, 1)  != '.' && is_dir("$dirname/themes/$file") && is_file("$dirname/themes/$file/theme.css")) {
                     $themeArray[] = $file;
                 }
             }

--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -412,7 +412,7 @@ class Flyspray
         $dirname = dirname(dirname(__FILE__));
         if ($handle = opendir($dirname . '/themes/')) {
             while (false !== ($file = readdir($handle))) {
-                if (substr($file, 0, 1)  != '.' && is_dir("$dirname/themes/$file") && is_file("$dirname/themes/$file/theme.css")) {
+                if ($file{0}  != '.' && is_dir("$dirname/themes/$file") && is_file("$dirname/themes/$file/theme.css")) {
                     $themeArray[] = $file;
                 }
             }

--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -408,18 +408,19 @@ class Flyspray
      */
     public static function listThemes()
     {
-        $theme_array = array();
-        if ($handle = opendir(dirname(dirname(__FILE__)) . '/themes/')) {
+        $themeArray = array();
+        $dirname = dirname(dirname(__FILE__));
+        if ($handle = opendir($dirname . '/themes/')) {
             while (false !== ($file = readdir($handle))) {
-                if ($file != '.' && $file != '..' && is_file(dirname(dirname(__FILE__)) . "/themes/$file/theme.css")) {
-                    $theme_array[] = $file;
+                if ($file != '.' && $file != '..' && is_dir("$dirname/themes/$file") && is_file("$dirname/themes/$file/theme.css")) {
+                    $themeArray[] = $file;
                 }
             }
             closedir($handle);
         }
 
-        sort($theme_array);
-        return $theme_array;
+        sort($themeArray);
+        return $themeArray;
     } // }}}
     // List a project's group {{{
     /**


### PR DESCRIPTION
fixes a warning triggered by is_file(). see more [here](https://groups.google.com/forum/#!topic/flyspray/uWg09IuJfUc)

note that every theme directory that start with '.' will be ignored