### PR TITLE
quick fix FS#1984

### DIFF
--- a/setup/upgrade/1.0/flyspray-install.xml
+++ b/setup/upgrade/1.0/flyspray-install.xml
@@ -481,7 +481,7 @@
       <KEY/>
       <AUTOINCREMENT/>
     </field>
-    <field name="resolution_name" type="C" size="30">
+    <field name="resolution_name" type="C" size="40">
       <NOTNULL/>
     </field>
     <field name="list_position" type="I" size="3">

--- a/setup/upgrade/1.0/upgrade.xml
+++ b/setup/upgrade/1.0/upgrade.xml
@@ -610,7 +610,7 @@
       <KEY/>
       <AUTOINCREMENT/>
     </field>
-    <field name="resolution_name" type="C" size="30">
+    <field name="resolution_name" type="C" size="40">
       <NOTNULL/>
     </field>
     <field name="list_position" type="I" size="3">


### PR DESCRIPTION
Make db field resolution_name the same size as maxlength in the CleanFS/templates/common.list.tpl
and the other *_name fields from list_*-tables. Because common.list.tpl is currently used also for other db tables, this is the easiest way to fix it.

A bigger solution would be either 
 - a template for each list_* table
or
 - reading INFORMATION_SCHEMA to get the real field size of the field in the list_* table