### PR TITLE
resize user_pass field for password_hash() usage

### DIFF
--- a/setup/upgrade/1.0/flyspray-install.xml
+++ b/setup/upgrade/1.0/flyspray-install.xml
@@ -1038,7 +1038,7 @@
     <field name="user_name" type="C" size="32">
       <NOTNULL/>
     </field>
-    <field name="user_pass" type="C" size="40"/>
+    <field name="user_pass" type="C" size="60"/>
     <field name="real_name" type="C" size="100">
       <NOTNULL/>
     </field>

--- a/setup/upgrade/1.0/upgrade.xml
+++ b/setup/upgrade/1.0/upgrade.xml
@@ -8,7 +8,7 @@
     <field name="user_name" type="C" size="32">
       <NOTNULL/>
     </field>
-    <field name="user_pass" type="C" size="40"/>
+    <field name="user_pass" type="C" size="60"/>
     <field name="real_name" type="C" size="100">
       <NOTNULL/>
     </field>


### PR DESCRIPTION
see http://php.net/manual/en/function.password-hash.php
They recommend 255 chars, but currently 60 chars is enough.
If we really need one day more than 60 chars we can change that too in later versions easily.