### PR TITLE
remove border-top line from #footer

### DIFF
--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -345,6 +345,8 @@ a.positive:active, button.positive:active {
 	box-shadow:none;
 	border:none;
 }
+#table tr:first-child td:first-child button.img.delete {display: none;}
+
 body .negative {color: #d12f19;}
 a.negative:hover {background-color: #fbe3e4;border: 1px solid #fbc2c4;color: #d12f19;}
 a.negative:active {background-color: #d12f19;border: 1px solid #d12f19;color: #fff;}

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -161,7 +161,6 @@ a:hover {color: #6699cc;}
   display: block;
   margin: 0px 20px 20px 20px;
   padding-top: 10px;
-  border-top: #e1e1e1 solid 1px;
   text-align: right;
 }
 #title {


### PR DESCRIPTION
I think it looks cleaner and we don't need this line here. There is enough optical separation from the page content because #tasklist or #toolbox have their own border and background.