### PR TITLE
add missing Insert_ID() for the db wrapper

### DIFF
--- a/includes/class.database.php
+++ b/includes/class.database.php
@@ -117,6 +117,16 @@ class Database
     }
 
     /**
+     * Insert_ID
+     * 
+     * @access public
+     */
+    public function Insert_ID()
+    {
+        return $this->dblink->Insert_ID();
+    }
+
+    /**
      * CountRows
      * Returns the number of rows in a result
      * @param object $result


### PR DESCRIPTION
This is IMHO important for the elimination of some race condition in the flyspray code.

Better use the autoincrement feature to avoid that. Instead of precalculating with an extra sql query. When precalculated, a second db connection could insert between the 2 queries leading to wrong data.