### PR TITLE
Use dokuwikicache for tasklist, fix FS#2021

### DIFF
--- a/includes/class.backend.php
+++ b/includes/class.backend.php
@@ -1431,6 +1431,13 @@ LEFT JOIN {users} u ON ass.user_id = u.user_id ';
             }
         }
 
+	# use preparsed task description cache for dokuwiki when possible
+	if($conf['general']['syntax_plugin']=='dokuwiki' && FLYSPRAY_USE_CACHE==true){
+		$select.=' cache.content desccache, ';
+		$from.='
+LEFT JOIN {cache} cache ON t.task_id=cache.topic AND cache.type="task" ';
+	}
+
         if (array_get($args, 'only_primary')) {
             $where[] = 'NOT EXISTS (SELECT 1 FROM {dependencies} dep WHERE dep.dep_task_id = t.task_id)';
         }

--- a/setup/upgrade/1.0/upgrade.xml
+++ b/setup/upgrade/1.0/upgrade.xml
@@ -1,5 +1,43 @@
 <?xml version="1.0"?>
 <schema version="0.3">
+  <table name="cache">
+    <field name="id" type="I" size="6">
+      <KEY/>
+      <AUTOINCREMENT/>
+    </field>
+    <field name="type" type="C" size="4">
+      <NOTNULL/>
+    </field>
+    <field name="content" type="XL">
+      <NOTNULL/>
+    </field>
+    <field name="topic" type="I" size="11">
+      <NOTNULL/>
+    </field>
+    <field name="last_updated" type="I" size="11">
+      <NOTNULL/>
+      <DEFAULT value="0"/>
+    </field>
+    <field name="project_id" type="I" size="11">
+      <NOTNULL/>
+      <DEFAULT value="0"/>
+    </field>
+    <field name="max_items" type="I" size="11">
+      <NOTNULL/>
+      <DEFAULT value="0"/>
+    </field>
+    <index name="cache_type">
+      <UNIQUE/>
+      <col>type</col>
+      <col>topic</col>
+      <col>project_id</col>
+      <col>max_items</col>
+    </index>
+    <index name="cache_type_topic">
+      <col>type</col>
+      <col>topic</col>
+    </index>
+  </table>
   <table name="users">
     <field name="user_id" type="I" size="3">
       <KEY/>

--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -355,7 +355,7 @@
         endforeach; ?>
 <td id="desc_<?php echo $task_details['task_id']; ?>" class="descbox box">
 <b><?php echo L('taskdescription'); ?></b>
-<?php echo $task_details['detailed_desc'] ? TextFormatter::render($task_details['detailed_desc'], 'task', $task_details['task_id']) : '<p>'.L('notaskdescription').'</p>'; ?>
+<?php echo $task_details['detailed_desc'] ? TextFormatter::render($task_details['detailed_desc'], 'task', $task_details['task_id'], $task_details['desccache']) : '<p>'.L('notaskdescription').'</p>'; ?>
 </td>
     </tr>
 <?php endforeach; ?>


### PR DESCRIPTION
This is for all the people who use dokuwiki syntax for flyspray instead of fullhtml/ckeditor.
(including bugs.flyspray.org)

It doesn't solve the issue in dokuwiki of exponential increased render time with growing count of tasks to show (scripts/index.php $perpage var), but the task list view on bugs.flyspray.org should drop from 5 sec (sic!) to nearly nothing (under 100ms for  whole page , tested with flyspray installed on a laptop)