### PR TITLE
Methods called from an incompatible context are deprecated/removed PHP>=5.4

### DIFF
--- a/setup/index.php
+++ b/setup/index.php
@@ -1083,7 +1083,7 @@ class Setup extends Flyspray
    * @param string $type The type of html format to return
    * @return string Depending on the type of format to return
    */
-   public function ReturnStatus($boolean, $type = 'yes')
+   public static function ReturnStatus($boolean, $type = 'yes')
    {
       // Do a switch on the type of status
       switch($type)


### PR DESCRIPTION
PHP5.6 => PHP Fatal error: Non-static method ...::...() cannot be called statically in...