### PR TITLE
Update tag class name

### DIFF
--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -596,10 +596,8 @@ form #taskdetailsfull {
 }
 #taskdetails #navigation {float: right;padding:6px;}
 #taskdetails h2 {color: #555;display:inline-block;}
-/* t_ now reserved classes for tags with their tag_id like t_123
- Couldnt use t123 due limited regex in css and some other classes start with 't' 
-*/
-.tags span, [class^='t_'] {
+/* t_ now reserved classes for tags with their tag_id like t_123 */
+.tags span, .tag {
     background: #eee none repeat scroll 0 0;
     border: 1px solid #ddd;
     border-radius: 3px;
@@ -609,16 +607,16 @@ form #taskdetailsfull {
     white-space: nowrap;
 }
 /* for fonticons in tags */
-[class^='t_']:before{
+.tag:before{
 	font-family:fontawesome;
 }
 /* style your tags by their tag_id, will be moved to custom_xxx.css in future */
 /* fa-eur */
 /*
-.t_1{background-color:#666;}
-.t_1:before{content:'\f153';color:#cc0;}
-.t_2{background-color:#0c0;}
-.t_3{background-color:#09c;}
+.tag.t_1{background-color:#666;}
+.tag.t_1:before{content:'\f153';color:#cc0;}
+.tag.t_2{background-color:#0c0;}
+.tag.t_3{background-color:#09c;}
 */
 #taskfields {
   width: 290px;


### PR DESCRIPTION
Namespace for a tag is naturally .tag, then you can add a custom class with class="tag t_123".
.t_123 has a special custom role and should be only added to default .tag style when needed, overriding default style.
Some other reasons are clearness, reuse and less rendering costs than regex.
Proposition for a respective update for details.view.tpl will be pulled shortly.