### PR TITLE
Rename taskid by task_id

### DIFF
--- a/themes/CleanFS/templates/details.edit.tpl
+++ b/themes/CleanFS/templates/details.edit.tpl
@@ -230,7 +230,7 @@
 		</div>
 		<br />
 		<?php endif; ?>
-		<button type="submit" class="positive" accesskey="s" onclick="return checkok('<?php echo Filters::noJsXSS($baseurl); ?>js/callbacks/checksave.php?time=<?php echo Filters::noXSS(time()); ?>&amp;taskid=<?php echo Filters::noXSS($task_details['task_id']); ?>', '<?php echo Filters::noJsXSS(L('alreadyedited')); ?>', 'taskeditform')"><?php echo Filters::noXSS(L('savedetails')); ?></button>
+		<button type="submit" class="positive" accesskey="s" onclick="return checkok('<?php echo Filters::noJsXSS($baseurl); ?>js/callbacks/checksave.php?time=<?php echo Filters::noXSS(time()); ?>&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>', '<?php echo Filters::noJsXSS(L('alreadyedited')); ?>', 'taskeditform')"><?php echo Filters::noXSS(L('savedetails')); ?></button>
 		<a class="button" href="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>"><?php echo Filters::noXSS(L('canceledit')); ?></a>
 	</div>
 </div>


### PR DESCRIPTION
/header.php has following FIXME mention with "a bit of work" I've done.

```
//FIXME: This is currently a workaround for the fact that parts of the code/templates use i.e. "taskid" and "task_id" for the same thing. This should be fixed cleanly, means a bit of work though.

if      (isset($_GET["task_id"])) $_GET["taskid"]  = $_GET["task_id"];
else if (isset($_GET["taskid"]))  $_GET["task_id"] = $_GET["taskid"];
if      (isset($_POST["task_id"])) $_POST["taskid"]  = $_POST["task_id"];
else if (isset($_POST["taskid"]))  $_POST["task_id"] = $_POST["taskid"];
if      (isset($_REQUEST["task_id"])) $_REQUEST["taskid"]  = $_REQUEST["task_id"];
else if (isset($_REQUEST["taskid"]))  $_REQUEST["task_id"] = $_REQUEST["taskid"];
```

The flow+context for which the workaround is necessary:
`GET /js/callbacks/checksave.php?time=1442933057&taskid=1 with referer /index.php?do=details&task_id=1&edit=yep

Only 1 file contains the taskid variant:
- /themes/CleanFS/templates/details.edit.tpl:233:
```
<button type="submit" class="positive" accesskey="s" onclick="return checkok('<?php echo Filters::noJsXSS($baseurl); ?>js/callbacks/checksave.php?time=<?php echo Filters::noXSS(time()); ?>&amp;taskid=<?php echo Filters::noXSS($task_details['task_id']); ?>', '<?php echo Filters::noJsXSS(L('alreadyedited')); ?>', 'taskeditform')"><?php echo Filters::noXSS(L('savedetails')); ?></button>
```

This patch changes "taskid" by "task_id" which seems to be standard convention here and lets the workaround as cleanable.