### PR TITLE
Fix reports URL in non rewrite mode

### DIFF
--- a/includes/class.tpl.php
+++ b/includes/class.tpl.php
@@ -960,7 +960,7 @@ function CreateURL($type, $arg1 = null, $arg2 = null, $arg3 = array())
             case 'myprofile':
             case 'register':
             case 'reports':
-            	$return = $url;
+            	$return = $url . '&project=' . $arg1;
             	break;
             case 'mytasks':
             	$return = $baseurl.'index.php?do=index&project='.$arg1.'&dev='.$arg2;


### PR DESCRIPTION
A missing project id in CreateURL function causes 2 bugs:

**1 - Context:**
- URL rewriting desactivated
- a project id is specified (we are NOT on a global view) such as /index.php?project=4
- CreateURL has no project_id in "reports" case
- We want to see the "reports", so we are clicking on "Reports" top menu

Actual behavior: project id is lost during this action, reports for another project are shown.
Expected behavior: To keep project id of current project and show the reports for this project.

**2 - Context:**
- URL rewriting desactivated
- a project id is NOT specified (we are on a global view) such as /index.php
- CreateURL has no project_id in "reports" case
- We want to see the "reports", so we are clicking on "Reports" top menu

Actual behavior: project id 0 is lost during this action, reports for a specified project are shown.
Expected behavior: To keep project id 0 and show the reports for all projects to which I have rights.

This patch changes actual by expected behaviors for twice.