### PR TITLE
Fix a PHP Notice + PDO call

### DIFF
--- a/js/callbacks/searchtask.php
+++ b/js/callbacks/searchtask.php
@@ -4,12 +4,23 @@ define('IN_FS', true);
 
 require_once('../../header.php');
 
-$_POST['detail'] = "%" . trim($_POST['detail']) . "%";
+// Require inputs
+if(!Post::has('detail') || !Post::has('summary'))
+{
+  return;
+}
+
+// Prepare SQL params
+$params = array(
+  'details' => "%" . Post::val('detail') . "%",
+  'summary' => "%" . Post::val('summary') . "%"
+);
+
 
 $sql = $db->Query('SELECT count(*) 
 		     FROM {tasks} t
 		     WHERE t.item_summary = ? AND t.detailed_desc like ?',
-		     $_POST);
+		     $params);
 
 $sametask = $db->fetchOne($sql);
 echo $sametask;


### PR DESCRIPTION
/js/callbacks/searchtask.php is called before saving a new task.

A direct call gives the following PHP notice:

```
Notice: Undefined index: detail in /js/callbacks/searchtask.php on line 7
Input Array does not match ?: SELECT count(*) 
		     FROM `flyspray_tasks` t
		     WHERE t.item_summary = '%%' AND t.detailed_desc like <br>
Query {SELECT count(*) 
		     FROM `flyspray_tasks` t
		     WHERE t.item_summary = ? AND t.detailed_desc like ?} with params {%%} Failed! (You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near &#039;&#039; at line 3)
```

A whitelisting of parameters before the PDO call seems to be more appropriated.

This patch improves 2 aspects:
- Incomplete calls have no information and no sql is used
- It whitelists only binded parameters to be PDO compliant