### PR TITLE
Fix a PHP Notice + PDO call

### DIFF
--- a/js/callbacks/searchtask.php
+++ b/js/callbacks/searchtask.php
@@ -35,7 +35,7 @@ $sql = $db->Query('SELECT count(*)
 		   FROM {tasks} t
 		   WHERE t.project_id = ? 
 		   	AND t.item_summary like ? 
-		   	AND t.detailed_desc like ?'
+		   	AND t.detailed_desc like ?',
 		   $params);
 $sametask = $db->fetchOne($sql);
 echo $sametask;

--- a/js/callbacks/searchtask.php
+++ b/js/callbacks/searchtask.php
@@ -1,27 +1,41 @@
 <?php
-
 define('IN_FS', true);
-
 require_once('../../header.php');
 
+
 // Require inputs
-if(!Post::has('detail') || !Post::has('summary'))
+if(!Post::has('detail') || !Post::has('summary') || !Post::has('project_id'))
 {
   return;
 }
 
+
+// Load user profile
+if (Cookie::has('flyspray_userid') && Cookie::has('flyspray_passhash')){
+  $user = new User(Cookie::val('flyspray_userid'));
+  $user->check_account_ok();
+}
+else {
+  $user = new User(0, $proj);
+}
+
+// Require right to open a task on current project
+if(!$user->can_open_task($proj)){
+  return;
+}
+
+
 // Prepare SQL params
 $params = array(
-  'details' => "%" . Post::val('detail') . "%",
-  'summary' => "%" . Post::val('summary') . "%"
+  'project_id' => Post::num('project_id'),
+  'details' => "%" . trim(Post::val('detail')) . "%",
+  'summary' => "%" . trim(Post::val('summary')) . "%"
 );
-
 
 $sql = $db->Query('SELECT count(*) 
 		     FROM {tasks} t
-		     WHERE t.item_summary = ? AND t.detailed_desc like ?',
+		     WHERE t.project_id = ? AND t.item_summary = ? AND t.detailed_desc like ?',
 		     $params);
-
 $sametask = $db->fetchOne($sql);
 echo $sametask;
 

--- a/js/callbacks/searchtask.php
+++ b/js/callbacks/searchtask.php
@@ -34,7 +34,7 @@ $params = array(
 $sql = $db->Query('SELECT count(*) 
 		   FROM {tasks} t
 		   WHERE t.project_id = ? 
-		   	AND t.item_summary = ? 
+		   	AND t.item_summary like ? 
 		   	AND t.detailed_desc like ?'
 		   $params);
 $sametask = $db->fetchOne($sql);

--- a/js/callbacks/searchtask.php
+++ b/js/callbacks/searchtask.php
@@ -14,8 +14,7 @@ if(!Post::has('detail') || !Post::has('summary') || !Post::has('project_id'))
 if (Cookie::has('flyspray_userid') && Cookie::has('flyspray_passhash')){
   $user = new User(Cookie::val('flyspray_userid'));
   $user->check_account_ok();
-}
-else {
+} else {
   $user = new User(0, $proj);
 }
 
@@ -28,14 +27,16 @@ if(!$user->can_open_task($proj)){
 // Prepare SQL params
 $params = array(
   'project_id' => Post::num('project_id'),
-  'details' => "%" . trim(Post::val('detail')) . "%",
-  'summary' => "%" . trim(Post::val('summary')) . "%"
+  'summary' => "%" . trim(Post::val('summary')) . "%",
+  'details' => "%" . trim(Post::val('detail')) . "%"
 );
 
 $sql = $db->Query('SELECT count(*) 
-		     FROM {tasks} t
-		     WHERE t.project_id = ? AND t.item_summary = ? AND t.detailed_desc like ?',
-		     $params);
+		   FROM {tasks} t
+		   WHERE t.project_id = ? 
+		   	AND t.item_summary = ? 
+		   	AND t.detailed_desc like ?'
+		   $params);
 $sametask = $db->fetchOne($sql);
 echo $sametask;
 


### PR DESCRIPTION
Related to #439 and Peter's comments (Thx)
- add removed trim
- add loading of user profile
- add "can_open_task" access checking
- add project_id in where clause

Other problems:
- dokuwki not supported+js enabled => controls should be done again in saving flow because can not be done in this one (js event only)
- details is optional: the 2 fields (summary+details, now project_id) are always sent. Optional points filled status and has no impact in control. If a future version plans to remove fields at submission when not required, we should patch it when done ?