### PR TITLE
Flyspray max file size for attachments

### DIFF
--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -82,6 +82,10 @@ class Flyspray
 
         $sizes = array();
         foreach (array(ini_get('memory_limit'), ini_get('post_max_size'), ini_get('upload_max_filesize')) as $val) {
+        	if($val === '-1'){
+				// unlimited value in php configuration
+				$val = PHP_INT_MAX;
+			}
             if (!$val || $val < 0) {
                 continue;
             }


### PR DESCRIPTION
When memory_limit or post_max_size or upload_max_filesize is set to unlimited value size doesn't be used for the computation of the attachments max size -  so if the three variable are set to -1 (unlimited) there are no attachment allowed but config allow them so in these case we could set value to a big number (php_int_max). 