### PR TITLE
add project_name as request parameter

### DIFF
--- a/header.php
+++ b/header.php
@@ -87,11 +87,21 @@ if (in_array(Req::val('do'), array('details', 'depends', 'editcomment'))) {
 
 if (!isset($project_id)) {
     // Determine which project we want to see
-    if (($project_id = Cookie::val('flyspray_project')) == '') {
-        $project_id = $fs->prefs['default_project'];
+    if ( Req::val('project_name') != '') {
+         $result = $db->Query('SELECT project_id
+                               FROM {projects} WHERE project_title = ?', array( Req::val('project_name')));
+         $project_id = $db->FetchOne($result);
     }
-    $project_id = Req::val('project', Req::val('project_id', $project_id));
+
+    if (!isset($project_id)) {
+        if (($project_id = Cookie::val('flyspray_project')) == '') {
+            $project_id = $fs->prefs['default_project'];
+        }
+        $project_id = Req::val('project', Req::val('project_id', $project_id));
+    }
 }
+
+
 
 $proj = new Project($project_id);
 # no more project cookie!

--- a/index.php
+++ b/index.php
@@ -104,7 +104,7 @@ if ($conf['general']['output_buffering'] == 'gzip' && extension_loaded('zlib'))
 $page = new FSTpl();
 
 // make sure people are not attempting to manually fiddle with projects they are not allowed to play with
-if (Req::has('project') && Req::val('project') != 0 && !$user->can_view_project(Req::val('project'))) {
+if ( ! $user->can_view_project(Req::val($project_id))) {
     Flyspray::show_error( L('nopermission') );
     exit;
 }
@@ -164,7 +164,7 @@ $sql = $db->Query('
 	ORDER BY project_is_active DESC, project_title'
 );
 
-# new: project_id as index for easier access, needs testing and maybe simplification 
+# new: project_id as index for easier access, needs testing and maybe simplification
 # similiar situation also includes/class.flyspray.php function listProjects()
 $sres=$db->FetchAllArray($sql);
 foreach($sres as $p){
@@ -193,7 +193,7 @@ $page->pushTpl('header.tpl');
 if (!defined('NO_DO')) {
     require_once(BASEDIR . "/scripts/$do.php");
 } else{
-    # not nicest solution, NO_DO currently only used on register actions 
+    # not nicest solution, NO_DO currently only used on register actions
     $page->pushTpl('register.ok.tpl');
 }
 $page->pushTpl('footer.tpl');


### PR DESCRIPTION
Hi

With this patch you can specify ?project_name=<project_title> instead of the ID with ?project in the URL.

I also think
line #56 in index.php is wrong

``` php
   list($proj_id, $orig_name, $file_name, $file_type) = $task;
```
and should rather read 

```php
   list($project_id, $orig_name, $file_name, $file_type) = $task;
```

but I didn't test that.

P.S. Caveat: I don't know PHP :)