### PR TITLE
Fix for FS#2075, users with empty jabber ID don't get notifications n…

### DIFF
--- a/includes/class.notify.php
+++ b/includes/class.notify.php
@@ -1038,7 +1038,7 @@ class Notifications {
             $get_users = $db->Query("SELECT DISTINCT u.user_id, u.email_address, u.jabber_id,
                                       u.notify_online, u.notify_type, u.notify_own, u.lang_code
                                 FROM {users} u
-                                WHERE u.jabber_id IN ('$desired')");
+                                WHERE u.jabber_id IN ('$desired') AND u.jabber_id <> ''");
 
             self::AssignRecipients($db->FetchAllArray($get_users), $emails, $jabbers, $onlines);
             


### PR DESCRIPTION
Fix for FS#2075, users with empty jabber ID don't get notifications now, so this fixes security problem,
but there is still problem with the notification logic, people with jabber ID and email are getting email
notifications parallel/instead of jabber notifications.