### PR TITLE
Add attribute id for each comment

### DIFF
--- a/themes/CleanFS/templates/details.tabs.comment.tpl
+++ b/themes/CleanFS/templates/details.tabs.comment.tpl
@@ -1,6 +1,6 @@
 <div id="comments" class="tab">
 	<?php foreach($comments as $comment): ?>
-		<div class="comment_container">
+		<div class="comment_container" id="<?php echo 'comment' . $comment['comment_id']; ?>">
 			<div class="comment_avatar"><?php echo tpl_userlinkavatar($comment['user_id'], $fs->prefs['max_avatar_size'], 'av_comment'); ?></div>
 			<div class="comment">
 				<div class="comment_header">


### PR DESCRIPTION
Notifications body contains an anchor #comment1 when a comment has been added.

ie: https://hostname/index.php?do=details&task_id=1#comment1

This patch adds the id attribute related to this anchor.