### PR TITLE
Update tag class name

### DIFF
--- a/themes/CleanFS/templates/details.view.tpl
+++ b/themes/CleanFS/templates/details.view.tpl
@@ -683,7 +683,7 @@ function quick_edit(elem, id)
 	<h2 class="summary severity<?php echo Filters::noXSS($task_details['task_severity']); ?>">
 	FS#<?php echo Filters::noXSS($task_details['task_id']); ?> - <?php echo Filters::noXSS($task_details['item_summary']); ?>
 	</h2>
-	<span class="tags"><?php foreach($tags as $tag): ?><span class="tag t<?php echo $tag['tag_id']; ?>"><?php echo Filters::noXSS($tag['tag']); ?></span><?php endforeach; ?></span>
+	<span class="tags"><?php foreach($tags as $tag): ?><span class="tag<?php echo isset($tag['class']) ? ' ' . $tag['class'] : ''; ?>"><?php echo Filters::noXSS($tag['tag']); ?></span><?php endforeach; ?></span>
 	<div id="taskdetailstext"><?php echo $task_text; ?></div>
 
         <?php $attachments = $proj->listTaskAttachments($task_details['task_id']);


### PR DESCRIPTION
- tag_id is not appropriated because it forces having one class per tag
- t prefix or other one (cus-tag-*) should be defined when adding/updating a new tag style class
- by this way, if no dedicated style has been defined, there no "t" class, no space in class attribute - keeping html short ;)
- this approach seems to be consistent with flyspray_list_tag.class nullable field

@peter In order to discuss about the tool to use for styling tags, we should speak on fs#2012 ?