### PR TITLE
Fix hover preview behaviour

### DIFF
--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -296,6 +296,7 @@
 		d.style.top = (cY+10) + "px";
 	}
 	function Show(elem, id) {
+		if(cY == 0) return;
 		var div = document.getElementById("desc_"+id);
 		AssignPosition(div);
 		div.style.display = "block";


### PR DESCRIPTION
When a page is loaded and mouse is hover a #tasklist tr, function Show is called (onmouseover).

Without a onmousemove event, the preview position is{top:10,left:10} which prints the div#desc_task_id at the top left of the window. It catches eye on this part of the window and disturbs. 

To reproduce this, put your cursor on a task and press F5 (Iceweasel, a little mouse move is needed on Chromium) .

There are several workarounds for this, but a simple and robust way to avoid that is to stop Show function before showing the div when cY=0.