### PR TITLE
Fix a PHP Parse error

### DIFF
--- a/themes/CleanFS/templates/roadmap.tpl
+++ b/themes/CleanFS/templates/roadmap.tpl
@@ -66,7 +66,7 @@ allTasks<?php echo Filters::noXSS($milestone['id']); ?> = [<?php foreach($milest
             }
             $effort = null;
         }
-    // }
+    }
     ?>
     <br />
     <?php
@@ -78,8 +78,6 @@ allTasks<?php echo Filters::noXSS($milestone['id']); ?> = [<?php foreach($milest
     if ($user->perms('view_current_effort_done')) {
         echo Filters::noXSS(L('opentasks')); ?> - <?php echo Filters::noXSS(L('currenteffortdone')); ?>: <?php echo effort::SecondsToString($actual_effort, $proj->prefs['hours_per_manday'], $proj->prefs['current_effort_done_format']);
     } ?>
-    <?php } 
-    ?>
 </p>
 
 <?php if(count($milestone['open_tasks'])): ?>


### PR DESCRIPTION
PHP Parse error:  syntax error, unexpected '}' in flyspray/themes/CleanFS/templates/roadmap.tpl on line 57
This error was first avoided by `// }` at the end of the foreach and then hidden by a `<?php } ?>` later in the code. See 2 parts of code which have been modified for details.