### PR TITLE
task value checks

### DIFF
--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -1032,6 +1032,8 @@ class Flyspray
     /**
      * Returns the key number of an array which contains an array like array($key => $value)
      * For use with SQL result arrays
+     * returns 0 for first index, so take care if you want check when useing to check if a value exists, use ===
+     *
      * @param string $key
      * @param string $value
      * @param array $array
@@ -1046,6 +1048,7 @@ class Flyspray
                 return $num;
             }
         }
+	return false;
     }
 
     /**

--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -295,7 +295,7 @@ switch ($action = Req::val('action'))
 		$osarray=$proj->listOs();
 	}
 	# FIXME what if we move to diff project, but os_id is defined for the old project only (not global)?
-	if( !is_numeric(Post::val('operating_system')) || false===Flyspray::array_find('os_id', Post::val('operating_system'), $osarray) ){
+	if( !is_numeric(Post::val('operating_system')) || ( isset($_POST['operating_system']) && $_POST['operating_system']!=='0' && false===Flyspray::array_find('os_id', Post::val('operating_system'), $osarray)) ){
 		$errors['invalidos']=1;
 	}
 

--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -185,7 +185,7 @@ switch ($action = Req::val('action'))
 		if($user->can_open_task($toproject)){
 			$move=1;
 		} else{
-			$errors['movingtoprojectforbidden']=1;
+			$errors['movingtorestrictedproject']=1;
 		}
 	}
 

--- a/index.php
+++ b/index.php
@@ -206,5 +206,5 @@ if(isset($_SESSION)) {
         $currentrequest = md5(serialize($_POST));
         unset($_SESSION['requests_hash'][$currentrequest]);
     }
-    unset($_SESSION['ERROR'], $_SESSION['SUCCESS']);
+    unset($_SESSION['ERROR'], $_SESSION['ERRORS'], $_SESSION['SUCCESS']);
 }

--- a/scripts/details.php
+++ b/scripts/details.php
@@ -59,6 +59,12 @@ if (!$user->can_view_task($task_details)) {
 			$page->assign('assignees', $db->FetchCol($assignees));
 		}
 		$page->assign('userlist', $userlist);
+
+		# user tries to move a task to a different project:
+		if($move==1){
+			$page->assign('move', 1);
+			$page->assign('toproject', $toproject);
+		}
 		$page->pushTpl('details.edit.tpl');
 	} else {
 		$prev_id = $next_id = 0;

--- a/themes/CleanFS/templates/details.edit.tpl
+++ b/themes/CleanFS/templates/details.edit.tpl
@@ -5,6 +5,9 @@
 # Maybe define a 'put visible_fields in default ordering'-button in project settings to let them make consistent with other projects and a no-brainer.
 # But let also project managers have the choice to sort to the order they want it.
 
+# FIXME If user wants a task to be moved to other project and a hidden list value (not in visible_fields) would be not legal in the target project:
+# Should we show that dropdown-list even if the field is not in the $fields-array to give the user the chance to resolve the issue?
+# The field list dropdown is not a secret for webtech-people, it is just not visible by css display:none;
 ?>
 <style>
 /* can be moved to default theme.css later, when the multiple errors/messages-feature is matured. currently used only here. */

--- a/themes/CleanFS/templates/details.edit.tpl
+++ b/themes/CleanFS/templates/details.edit.tpl
@@ -1,13 +1,11 @@
 <?php echo tpl_form(Filters::noXSS(CreateUrl('details', $task_details['task_id'])),null,null,null,'id="taskeditform"'); ?>
-<!--
-<div id="actionbar">
-	<button class="button positive" type="submit" accesskey="s" onclick="return checkok('<?php echo Filters::noJsXSS($baseurl); ?>js/callbacks/checksave.php?time=<?php echo Filters::noXSS(time()); ?>&amp;task_id=<?php echo Filters::noXSS($task_details['task_id']); ?>', '<?php echo Filters::noJsXSS(L('alreadyedited')); ?>', 'taskeditform')"><?php echo Filters::noXSS(L('savedetails')); ?></button>
-	<a class="button" href="<?php echo Filters::noXSS(CreateUrl('details', $task_details['task_id'])); ?>"><?php echo Filters::noXSS(L('canceledit')); ?></a>
-	<div class="clear"></div>
-</div>
--->
 <!-- Grab fields wanted for this project so we can only show those we want -->
-<?php $fields = explode( ' ', $proj->prefs['visible_fields'] ); ?>
+<?php $fields = explode( ' ', $proj->prefs['visible_fields'] ); 
+# FIXME The template should respect the ordering of 'visible_fields', aren't they?
+# Maybe define a 'put visible_fields in default ordering'-button in project settings to let them make consistent with other projects and a no-brainer.
+# But let also project managers have the choice to sort to the order they want it.
+
+?>
 <style>
 /* can be moved to default theme.css later, when the multiple errors/messages-feature is matured. currently used only here. */
 .errorinput{color:#c00 !important;}
@@ -88,14 +86,14 @@
 	</li>
 	<!-- Reported In -->
 	<li<?php echo in_array('reportedin', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="reportedver"<?php echo isset($_SESSION['ERRORS']['invalidversion']) ? ' class="errorinput" title="'.eL('invalidversion').'"':''; ?>><?php echo Filters::noXSS(L('reportedversion')); ?></label>
+		<label for="reportedver"<?php echo isset($_SESSION['ERRORS']['invalidreportedversion']) ? ' class="errorinput" title="'.eL('invalidreportedversion').'"':''; ?>><?php echo Filters::noXSS(L('reportedversion')); ?></label>
 		<select id="reportedver" name="reportedver">
 		<?php echo tpl_options($proj->listVersions(false, 2, $task_details['product_version']), Req::val('reportedver', $task_details['product_version'])); ?>
 		</select>
 	</li>
 	<!-- Due Version -->
 	<li<?php echo in_array('dueversion', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="dueversion"<?php echo isset($_SESSION['ERRORS']['invalidversion']) ? ' class="errorinput" title="'.eL('invalidversion').'"':''; ?>><?php echo Filters::noXSS(L('dueinversion')); ?></label>
+		<label for="dueversion"<?php echo isset($_SESSION['ERRORS']['invaliddueversion']) ? ' class="errorinput" title="'.eL('invaliddueversion').'"':''; ?>><?php echo Filters::noXSS(L('dueinversion')); ?></label>
 		<select id="dueversion" name="closedby_version" <?php echo tpl_disableif(!$user->perms('modify_all_tasks')) ?>>
 		<option value="0"><?php echo Filters::noXSS(L('undecided')); ?></option>
 		<?php echo tpl_options($proj->listVersions(false, 3), Req::val('closedby_version', $task_details['closedby_version'])); ?>

--- a/themes/CleanFS/templates/details.edit.tpl
+++ b/themes/CleanFS/templates/details.edit.tpl
@@ -12,6 +12,7 @@
 <style>
 /* can be moved to default theme.css later, when the multiple errors/messages-feature is matured. currently used only here. */
 .errorinput{color:#c00 !important;}
+li.errorinput{background-color:#fc9;}
 .errorinput::before{display:block;content: attr(title);}
 </style>
 <div id="taskdetails">
@@ -88,10 +89,22 @@
 		</select>
 	</li>
 	<!-- Reported In -->
-	<li<?php echo in_array('reportedin', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="reportedver"<?php echo isset($_SESSION['ERRORS']['invalidreportedversion']) ? ' class="errorinput" title="'.eL('invalidreportedversion').'"':''; ?>><?php echo Filters::noXSS(L('reportedversion')); ?></label>
+	<li<?php
+		# show the reportedversion if invalid when moving tasks - even if not in the visible list.
+		echo isset($_SESSION['ERRORS']['invalidreportedversion']) ? ' class="errorinput"' : (in_array('reportedin', $fields) ? '' : ' style="display:none"'); ?>>
+		<?php echo isset($_SESSION['ERRORS']['invalidreportedversion']) ? '<span class="errorinput" style="display:block;">'.eL('invalidreportedversion').'</span>' : ''; ?>
+		<label for="reportedver"><?php echo Filters::noXSS(L('reportedversion')); ?></label>
 		<select id="reportedver" name="reportedver">
-		<?php echo tpl_options($proj->listVersions(false, 2, $task_details['product_version']), Req::val('reportedver', $task_details['product_version'])); ?>
+			<?php
+			# TODO seperate also global option from current project option by optgroup or css classes
+			# we need better listVersions() / tpl_options() / tpl_select()
+			echo (isset($move) && $move==1)? '<optgroup label="'.L('currentproject').'">' :'';
+			echo tpl_options($proj->listVersions(false, 2, $task_details['product_version']), Req::val('reportedver', $task_details['product_version'])); ?>
+			echo (isset($move) && $move==1)? '</optgroup>' :'';
+			<?php
+			if(isset($move) && $move==1) :
+				echo '<optgroup label="'.L('targetproject').'">'.tpl_options($toproject->listVersions(false, false, $task_details['product_version']), Req::val('reportedver', $task_details['product_version'])).'</optgroup>';
+			endif; ?>
 		</select>
 	</li>
 	<!-- Due Version -->

--- a/themes/CleanFS/templates/details.edit.tpl
+++ b/themes/CleanFS/templates/details.edit.tpl
@@ -142,7 +142,7 @@
 
 	<!-- If there is only one choice of projects, then don't bother showing it -->
 	<li<?php echo (count($fs->projects) > 1) ? '' : ' style="display:none"'; ?>>
-		<label for="project_id"><?php echo Filters::noXSS(L('attachedtoproject')); ?></label>
+		<label for="project_id"<?php echo isset($_SESSION['ERRORS']['movingtorestrictedproject']) ? ' class="errorinput" title="'.eL('movingtorestrictedproject').'"':''; ?>><?php echo Filters::noXSS(L('attachedtoproject')); ?></label>
 		<select name="project_id" id="project_id">
 		<?php echo tpl_options($fs->projects, Req::val('project_id', $proj->id)); ?>
 		</select>

--- a/themes/CleanFS/templates/details.edit.tpl
+++ b/themes/CleanFS/templates/details.edit.tpl
@@ -8,6 +8,11 @@
 -->
 <!-- Grab fields wanted for this project so we can only show those we want -->
 <?php $fields = explode( ' ', $proj->prefs['visible_fields'] ); ?>
+<style>
+/* can be moved to default theme.css later, when the multiple errors/messages-feature is matured. currently used only here. */
+.errorinput{color:#c00 !important;}
+.errorinput::before{display:block;content: attr(title);}
+</style>
 <div id="taskdetails">
 	<input type="hidden" name="action" value="details.update" />
 	<input type="hidden" name="edit" value="1" />
@@ -17,14 +22,14 @@
 	<ul class="form_elements slim">
 	<!-- Status -->
 	<li<?php echo in_array('status', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="status"><?php echo Filters::noXSS(L('status')); ?></label>
+		<label for="status"<?php echo isset($_SESSION['ERRORS']['invalidstatus']) ? ' class="errorinput" title="'.eL('invalidstatus').'"':''; ?>><?php echo Filters::noXSS(L('status')); ?></label>
 		<select id="status" name="item_status" <?php echo tpl_disableif(!$user->perms('modify_all_tasks')); ?>>
 		<?php echo tpl_options($proj->listTaskStatuses(), Req::val('item_status', ($user->perms('modify_all_tasks') ? $task_details['item_status'] : STATUS_UNCONFIRMED))); ?>
 		</select>
 	</li>
 	<!-- Progress -->
 	<li<?php echo in_array('progress', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="percent"><?php echo Filters::noXSS(L('percentcomplete')); ?></label>
+		<label for="percent"<?php echo isset($_SESSION['ERRORS']['invalidprogress']) ? ' class="errorinput" title="'.eL('invalidprogress').'"':''; ?>><?php echo Filters::noXSS(L('percentcomplete')); ?></label>
 		<select id="percent" name="percent_complete" <?php echo tpl_disableif(!$user->perms('modify_all_tasks')) ?>>
 		<?php $arr = array(); for ($i = 0; $i<=100; $i+=10) $arr[$i] = $i.'%'; ?>
 		<?php echo tpl_options($arr, Req::val('percent_complete', $task_details['percent_complete'])); ?>
@@ -32,14 +37,14 @@
 	</li>
 	<!-- Task Type-->
 	<li<?php echo in_array('tasktype', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="tasktype"><?php echo Filters::noXSS(L('tasktype')); ?></label>
+		<label for="tasktype"<?php echo isset($_SESSION['ERRORS']['invalidtasktype']) ? ' class="errorinput" title="'.eL('invalidtasktype').'"':''; ?>><?php echo Filters::noXSS(L('tasktype')); ?></label>
 		<select id="tasktype" name="task_type">
 		<?php echo tpl_options($proj->listTaskTypes(), Req::val('task_type', $task_details['task_type'])); ?>
 		</select>
 	</li>
 	<!-- Category -->
 	<li<?php echo in_array('category', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="category"><?php echo Filters::noXSS(L('category')); ?></label>
+		<label for="category"<?php echo isset($_SESSION['ERRORS']['invalidcategory']) ? ' class="errorinput" title="'.eL('invalidcategory').'"':''; ?>><?php echo Filters::noXSS(L('category')); ?></label>
 		<select id="category" name="product_category">
 		<?php echo tpl_options($proj->listCategories(), Req::val('product_category', $task_details['product_category'])); ?>
 		</select>
@@ -62,35 +67,35 @@
 	</li>
 	<!-- OS -->
 	<li<?php echo in_array('os', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="os"><?php echo Filters::noXSS(L('operatingsystem')); ?></label>
+		<label for="os"<?php echo isset($_SESSION['ERRORS']['invalidos']) ? ' class="errorinput" title="'.eL('invalidos').'"':''; ?>><?php echo Filters::noXSS(L('operatingsystem')); ?></label>
 		<select id="os" name="operating_system">
 		<?php echo tpl_options($proj->listOs(), Req::val('operating_system', $task_details['operating_system'])); ?>
 		</select>
 	</li>
 	<!-- Severity -->
 	<li<?php echo in_array('severity', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="severity"><?php echo Filters::noXSS(L('severity')); ?></label>
+		<label for="severity"<?php echo isset($_SESSION['ERRORS']['invalidseverity']) ? ' class="errorinput" title="'.eL('invalidseverity').'"':''; ?>><?php echo Filters::noXSS(L('severity')); ?></label>
 		<select id="severity" name="task_severity">
 		 <?php echo tpl_options($fs->severities, Req::val('task_severity', $task_details['task_severity'])); ?>
 		</select>
 	</li>
 	<!-- Priority -->
 	<li<?php echo in_array('priority', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="priority"><?php echo Filters::noXSS(L('priority')); ?></label>
+		<label for="priority"<?php echo isset($_SESSION['ERRORS']['invalidpriority']) ? ' class="errorinput" title="'.eL('invalidpriority').'"':''; ?>><?php echo Filters::noXSS(L('priority')); ?></label>
 		<select id="priority" name="task_priority" <?php echo tpl_disableif(!$user->perms('modify_all_tasks')) ?>>
 		<?php echo tpl_options($fs->priorities, Req::val('task_priority', $task_details['task_priority'])); ?>
 		</select>
 	</li>
 	<!-- Reported In -->
 	<li<?php echo in_array('reportedin', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="reportedver"><?php echo Filters::noXSS(L('reportedversion')); ?></label>
+		<label for="reportedver"<?php echo isset($_SESSION['ERRORS']['invalidversion']) ? ' class="errorinput" title="'.eL('invalidversion').'"':''; ?>><?php echo Filters::noXSS(L('reportedversion')); ?></label>
 		<select id="reportedver" name="reportedver">
 		<?php echo tpl_options($proj->listVersions(false, 2, $task_details['product_version']), Req::val('reportedver', $task_details['product_version'])); ?>
 		</select>
 	</li>
 	<!-- Due Version -->
 	<li<?php echo in_array('dueversion', $fields) ? '' : ' style="display:none"'; ?>>
-		<label for="dueversion"><?php echo Filters::noXSS(L('dueinversion')); ?></label>
+		<label for="dueversion"<?php echo isset($_SESSION['ERRORS']['invalidversion']) ? ' class="errorinput" title="'.eL('invalidversion').'"':''; ?>><?php echo Filters::noXSS(L('dueinversion')); ?></label>
 		<select id="dueversion" name="closedby_version" <?php echo tpl_disableif(!$user->perms('modify_all_tasks')) ?>>
 		<option value="0"><?php echo Filters::noXSS(L('undecided')); ?></option>
 		<?php echo tpl_options($proj->listVersions(false, 3), Req::val('closedby_version', $task_details['closedby_version'])); ?>
@@ -154,7 +159,7 @@
 	</div>
 </div>
 <div id="taskdetailsfull">
-	<label for="itemsummary" class="summary">FS#<?php echo Filters::noXSS($task_details['task_id']); ?> <?php echo Filters::noXSS(L('summary')); ?>:
+	<label for="itemsummary"<?php echo isset($_SESSION['ERRORS']['summaryrequired']) ? ' class="summary errorinput" title="'.eL('summaryrequired').'"':' class="summary"'; ?>>FS#<?php echo Filters::noXSS($task_details['task_id']); ?> <?php echo Filters::noXSS(L('summary')); ?>:
 		<input placeholder="<?php echo Filters::noXSS(L('summary')); ?>" type="text" name="item_summary" id="itemsummary" maxlength="100" value="<?php echo Filters::noXSS(Req::val('item_summary', $task_details['item_summary'])); ?>" />
 	</label>
 	<?php

--- a/themes/CleanFS/templates/details.edit.tpl
+++ b/themes/CleanFS/templates/details.edit.tpl
@@ -192,7 +192,7 @@
 		<button id="addlinkbox_addalink" tabindex="10" type="button" onclick="addLinkField('addlinkbox')"><?php echo Filters::noXSS(L('addalink')); ?></button>
 		<button id="addlinkbox_addanotherlink" tabindex="10" style="display: none" type="button" onclick="addLinkField('addlinkbox')"><?php echo Filters::noXSS(L('addalink')); ?></button>
 		<br />
-		<span style="display: none">
+		<span style="display: none"><?php /* this span is shown/copied by javascript when adding links */ ?>
 			<input tabindex="8" class="text" type="text" maxlength="100" name="userlink[]" />
 			<a href="javascript://" tabindex="9" class="button fa fa-remove fa-lg" title="<?php echo Filters::noXSS(L('remove')); ?>" onclick="removeLinkField(this, 'addlinkbox');"></a><br />
 		</span>
@@ -215,7 +215,7 @@
 			<?php echo Filters::noXSS(L('attachanotherfile')); ?> (<?php echo Filters::noXSS(L('max')); ?> <?php echo Filters::noXSS($fs->max_file_size); ?> <?php echo Filters::noXSS(L('MiB')); ?>)
 		</button>
 		<br />
-		<span style="display: none"><?php // this span is shown/copied in javascript when adding files ?>
+		<span style="display: none"><?php /* this span is shown/copied by javascript when adding files */ ?>
 			<input tabindex="5" class="file" type="file" size="55" name="usertaskfile[]" />
 			<a href="javascript://" tabindex="6" class="button fa fa-remove fa-lg" title="<?php echo Filters::noXSS(L('remove')); ?>" onclick="removeUploadField(this);"></a><br />
 		</span>


### PR DESCRIPTION
This patch avoids setting invalid list values by:
- constructed requests by authorized, but bad users.
- accidently setting invalid list values when moving a task to different project by authorized users.

Not perfect and finished the task-to-different-project user interactions/messages, but better than before and fixes sec issue.