### PR TITLE
Add email format control

### DIFF
--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -845,6 +845,13 @@ switch ($action = Req::val('action'))
             break;
         }
 
+        // Check email format
+        if (!Post::val('email_address') || !Flyspray::check_email(Post::val('email_address')))
+        {
+            Flyspray::show_error(L('novalidemail'));
+            break;
+        }
+
         if (Post::val('user_pass') != Post::val('user_pass2')) {
             Flyspray::show_error(L('nomatchpass'));
             break;

--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -1360,6 +1360,13 @@ switch ($action = Req::val('action'))
                     break;
                 }
 
+                // Check email format
+                if (!Post::val('email_address') || !Flyspray::check_email(Post::val('email_address')))
+                {
+                    Flyspray::show_error(L('novalidemail'));
+                    break;
+                }
+
                 if ( (!$user->perms('is_admin') || $user->id == Post::val('user_id')) && !Post::val('oldpass')
                 && (Post::val('changepass') || Post::val('confirmpass')) ) {
                     Flyspray::show_error(L('nooldpass'));


### PR DESCRIPTION
- Trying to add an user with a bad email (such as "test") throws the following swift exception: 
```
Completely unexpected exception: Address in mailbox given [test] does not comply with RFC 2822, 3.6.2.
This should never happend, please inform Flyspray Developers
```

- Updating a user with a bad email format from admin & myprofile should not be allowed

This patch fixes both.