### PR TITLE
Fix perms potential weakness

### DIFF
--- a/includes/class.user.php
+++ b/includes/class.user.php
@@ -78,7 +78,7 @@ class User
     }
 
     public function perms($name, $project = null) {
-        if (is_null($project)) {
+        if (is_null($project) || is_array($project)) {
             global $proj;
             $project = $proj->id;
         }


### PR DESCRIPTION
Calls with a project identifier in array format are crashing the script with PHP warnings. Several do actions are concerned.
```
GET /index.php?do=reports&project[]=1
```
=>
```
Warning: Illegal offset type in /includes/class.user.php on line 86
```