### PR TITLE
Show project overruling group settings

### DIFF
--- a/themes/CleanFS/templates/pm.groups.tpl
+++ b/themes/CleanFS/templates/pm.groups.tpl
@@ -103,12 +103,17 @@ foreach ($merge as $group){
 </thead>
 <tbody>
 <?php foreach ($perm_fields as $p): ?>
-<tr>
+<tr<?php 
+# TODO view_own_tasks
+echo ($p=='view_tasks'     && $proj->prefs['others_view']) ?       ' class="everybody"':'';
+echo ($p=='view_roadmap'   && $proj->prefs['others_viewroadmap']) ?' class="everybody"':'';
+echo ($p=='open_new_tasks' && $proj->prefs['anon_open']) ?         ' class="everybody"':'';
+?>>
 <th><?php echo eL(str_replace('_', '', $p)); ?></th>
 <?php
 require_once('permicons.tpl');
 $i=0; 
-# TODO: make it visible that a granted 'view_tasks' overrules 'view_groups_tasks' and 'own_tasks'. (like is_admin)
+
 foreach($perms[$p] as $val){
   if ($perms['is_admin'][$i]==1 && $val == 0){
     if(isset($permicons[$p])){

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -1137,6 +1137,10 @@ ul.slim .userSelectWidget select {width:100%;}
 #idtablesys {background-color: #eee;}
 #listpositionnew {width:100%;}
 
+.perms .everybody{position:relative;}
+.perms .everybody th:before {content:'Allowed for everybody - project setting overrules this group setting!';color:#900;position:absolute;left:2px;z-index:2;text-shadow:0 0 2px #fff;top:-2px;}
+.perms .everybody > * { background-color: #6c6; }
+
 /* closing task form */
 div#closeform {
   border-radius: 3px;


### PR DESCRIPTION
There are a few project wide permission settings that overrule similiar group permission settings.

This patch makes this overruling visible on the group permissions page of a project to reduce the probability of a misconfiguration.