### PR TITLE
Fix table position

### DIFF
--- a/themes/CleanFS/templates/pm.groups.tpl
+++ b/themes/CleanFS/templates/pm.groups.tpl
@@ -72,7 +72,7 @@ foreach ($merge as $group){
 }
 ?>
 <style>
-.perms {border-collapse:collapse;margin-top:20px;}
+.perms {border-collapse:collapse;margin-top:20px;display:block;}
 .perms tbody tr:hover {background-color:#eee;}
 .perms td, .perms th{border:1px solid #999;}
 .perms thead th, .perms thead td {text-align:center;}


### PR DESCRIPTION
With a large definition (more than 1280) and default group definitions (6 columns), the table does not stay left align. It aligns with the line above (forms and buttons).
Adding a `display:block` enforces its left alignment.
```GET /index.php?project=1&do=pm&area=groups```