### PR TITLE
remove of exclusive sponsor link from footer

### DIFF
--- a/themes/CleanFS/templates/footer.tpl
+++ b/themes/CleanFS/templates/footer.tpl
@@ -1,10 +1,8 @@
 <?php $this->display('shortcuts.tpl'); ?>
-
 </div>
 <p id="footer">
     <!-- Please don't remove this line - it helps promote Flyspray -->
-    <a href="http://flyspray.org/" class="offsite"><?php echo Filters::noXSS(L('poweredby')); ?><?php if ($user->perms('is_admin')): ?> <?php echo Filters::noXSS($fs->version); ?> <?php endif; ?></a><br/>
-    <i><a href="http://www.thevelozgroup.com"><?php echo Filters::noXSS(L('sponsoredby')); ?> The Veloz Group</a></i>
+    <a href="http://flyspray.org/" class="offsite"><?php echo Filters::noXSS(L('poweredby')); ?><?php if ($user->perms('is_admin')): ?> <?php echo Filters::noXSS($fs->version); ?> <?php endif; ?></a>
 </p>
 </body>
 </html>


### PR DESCRIPTION
* I think it prevents adoptation of the Flyspray.
* And I also think it prevents peoples from contributing/volunteering in Flyspray development. Flyspray was and is developed since 15 years by many people from over the world. An exclusive linking to one company url is not appropriate for a software developed by so many volunteers, beside there was/is not any sponsoring or code contribution for at least 1 year.