### PR TITLE
Fix a JS error

### DIFF
--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -401,7 +401,6 @@ echo tpl_select(
 <!-- Bulk editing Tasks -->
 <?php if (!$user->isAnon() && $proj->id !=0 && $total): ?>
 <!-- Grab fields wanted for this project so we only show those specified in the settings -->
-<script>Effect.Fade('bulk_edit_selectedItems');</script>
 <div id="bulk_edit_selectedItems" style="display:none">
     <fieldset>
         <legend><b><?php echo Filters::noXSS(L('updateselectedtasks')); ?></b></legend>


### PR DESCRIPTION
This effect will never apply and issues an error when viewing a list of tasks.

```GET /index.php?project=1&do=tasklist```