### PR TITLE
Fix a notice

### DIFF
--- a/scripts/index.php
+++ b/scripts/index.php
@@ -199,7 +199,8 @@ function tpl_draw_cell($task, $colname, $format = "<td class='%s'>%s</td>") {
 			$tagclass=explode(',', $task['tagclass']);
 			$tgs='';
 			for($i=0;$i< count($tags); $i++){
-				$tgs.='<i class="tag t'.$tagids[$i].($tagclass[$i] ? ' '.$tagclass[$i]:'').'" title="'.$tags[$i].'"></i>';
+				$tgs.='<i class="tag t'.$tagids[$i]
+					.(isset($tagclass[$i]) ? ' ' . $tagclass[$i] : '').'" title="'.$tags[$i].'"></i>';
 			}
                         $value.=$tgs;
 		}


### PR DESCRIPTION
This notice occurred when class name is set to NULL for a tag (list_tag table).

```GET https://bugs.flyspray.org/index.php?project=0&do=index```