### PR TITLE
Bugfix with quickediting estimate_efforts

### DIFF
--- a/header.php
+++ b/header.php
@@ -77,7 +77,7 @@ text-decoration: none;
 }
 
 // Any "do" mode that accepts a task_id field should be added here.
-if (in_array(Req::val('do'), array('details', 'depends', 'editcomment'))) {
+if (in_array(Req::val('do'), array('details', 'depends', 'editcomment')) || Req::val('name') == "estimated_effort") {
     if (Req::num('task_id')) {
         $result = $db->Query('SELECT project_id FROM {tasks} WHERE task_id = ?', array(Req::num('task_id')));
         $project_id = $db->FetchOne($result);


### PR DESCRIPTION
This little bugfix repairs the quickediting for estimate_efforts. It's kind a little bit dirty, I think, because the quickedit-functions doesn't have a "do"-function. The edit of the header-file is needed for the quickedit.php on line 46-48. This lines need a correct project-Object. Previously the default-project was choosen there...