### PR TITLE
Typo in url-rewriting

### DIFF
--- a/htaccess.dist
+++ b/htaccess.dist
@@ -116,7 +116,7 @@ RewriteRule ^index$ index.php?do=index [L,QSA]
 RewriteRule ^index/proj([0-9]+)$ index.php?do=index&project=$1 [L,QSA]
 RewriteRule ^newmultitasks/proj([0-9+])$ index.php?do=newmultitasks&project=$1 [L,QSA]
 
-RewriteRule ^proj([0-9+])/dev([0-9]+)$ index.php?project=$1&do=index&dev=$2 [L,QSA]
+RewriteRule ^proj([0-9]+)/dev([0-9]+)$ index.php?project=$1&do=index&dev=$2 [L,QSA]
 RewriteRule ^proj([0-9]+)$ index.php?project=$1 [L,QSA]
 
 </IfModule>


### PR DESCRIPTION
Fixes a problem if url-rewriting is activated. 'My assigned tasks' is now navigable again in a specific project.