### PR TITLE
fix current js-tabs for css mediaqueries

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -34,12 +34,16 @@ function showTabById(tabid, noEval) { // {{{
   }
   for (i=0; i<divs.length; i++) {
     if (divs[i].className && (divs[i].className.indexOf('tab') > -1)) {
-      divs[i].style.display = 'none';
+      //divs[i].style.display = 'none';
+      if (divs[i].className && (divs[i].className.indexOf(' active') > -1)) {
+        divs[i].className = divs[i].className.substr(0, divs[i].className.length-7);
+      }
     }
   }
 
   if (tab) {
-    tab.style.display = 'block';
+    //tab.style.display = 'block';
+    tab.className = tab.className +' active';
 
     if (submenu) {
       var links = submenu.getElementsByTagName('a');

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -773,6 +773,8 @@ kbd {background-color: #eee;border: 1px solid #ccc;border-radius: 4px;padding: 2
 }
 #submenu li {display: inline;}
 div.tab {margin: 10px 1ex 10px 0;padding: 1ex 1ex 0;}
+.tab{display:none;}
+.tab.active{display:block;}
 * html .tab div.clear {clear: none;height: 14em;}
 div.comment_container {margin: 5px;}
 div.comment_container .comment_avatar {	min-width: 50px;display: inline-block;}


### PR DESCRIPTION
e.g. enables tab styling like showing comments  on task details page side-by-side with task description on wide desktop screens, but below on smaller screens - without touching the current template files.