### PR TITLE
Add hyphenation and long word breaking

### DIFF
--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -143,6 +143,15 @@ pre.code {
     background-color: #fff;
     border: 1px solid #ddd;
     overflow:auto;
+    -ms-hyphens: auto;
+    -moz-hyphens: auto;
+    -webkit-hyphens: auto;
+    -o-hyphens: auto;
+    hyphens: auto;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    -ms-word-break: break-all;
+    word-break: break-word;
 }
 
 li ul, li ol { margin: 0; }


### PR DESCRIPTION
- Adds a hyphen where the word breaks, if supported
  -ms-hyphens: auto;
  -moz-hyphens: auto;
  -webkit-hyphens: auto;
  -o-hyphens: auto;
  hyphens: auto;

- Wraps on overflow
  overflow-wrap: break-word;
  word-wrap: break-word;

- Breaks long words (such as aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
  -ms-word-break: break-all;
  word-break: break-word;

Word breaks is not well supported by webkit as it breaks a word arbitrary, this is why I don't use -webkit-word-break