### PR TITLE
Allow admin to change own password

### DIFF
--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -1372,7 +1372,7 @@ switch ($action = Req::val('action'))
                     break;
                 }
 
-                if ( (!$user->perms('is_admin') || $user->id == Post::val('user_id')) && !Post::val('oldpass')
+                if ( (!$user->perms('is_admin') && $user->id == Post::val('user_id')) && !Post::val('oldpass')
                 && (Post::val('changepass') || Post::val('confirmpass')) ) {
                     Flyspray::show_error(L('nooldpass'));
                     break;


### PR DESCRIPTION
Without this change, admin can not change own password. Gets "no old password given" error. Change 6f52db86d64f78e515865de29ccf683dc4f409ff removed old password text box from admin "edit user" page. However, check for old-password required did not correct check for 'is_admin'.

ref: FS#2130