### PR TITLE
Update pre_install.tpl

### DIFF
--- a/setup/templates/pre_install.tpl
+++ b/setup/templates/pre_install.tpl
@@ -19,7 +19,12 @@
 			<td>XML Extension</td>
 			<td align="left"><b><?php echo Setup::ReturnStatus($xmlStatus); ?></b></td>
 			<td>&nbsp;</td>
-			</tr>
+		</tr>
+		<tr>
+			<td>cURL Library</td>
+			<td align="left"><b><?php echo Setup::ReturnStatus(extension_loaded('curl'), 'yes'); ?></b></td>
+			<td>required if you want allow Oauth2 authentications</td>
+		</tr>
 		<tr>
 			<td>GD Library</td>
 			<td align="left"><b><?php echo Setup::ReturnStatus(extension_loaded('gd'), 'yes'); ?></b></td>


### PR DESCRIPTION
Fix FS#2131

oauth2-client uses guzzle which uses curl for doing http requests.

On minimal server installations it can happen that php5 core package is installed, but curl extension not yet.

This check just informs about if curl is installed or if he should install an extra package.
(named php5-curl for instance on linux package managment for php5 series)