### PR TITLE
Fix page redirect after admin updates user info

### DIFF
--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -1593,7 +1593,13 @@ switch ($action = Req::val('action'))
         }
 
         $_SESSION['SUCCESS'] = L('userupdated');
-        Flyspray::Redirect(CreateURL('myprofile'));
+        if ($action === 'myprofile.edituser') {
+                Flyspray::Redirect(CreateURL('myprofile'));
+        } elseif ($action === 'admin.edituser' && Post::val('area') === 'users') {
+                Flyspray::Redirect(CreateURL('edituser', Post::val('user_id')));
+        } else {
+                Flyspray::Redirect(CreateURL('user', Post::val('user_id')));
+        }
         break;
         // ##################
         // approving a new user registration


### PR DESCRIPTION
Fixes page redirect after admin edits a user profile. After update, FS returns to selected user profile instead of the admin user profile.

Closes FS#2136 (https://bugs.flyspray.org)
