### PR TITLE
raise adodb minimal version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "LGPL-2.1",
     "require": {
         "swiftmailer/swiftmailer": "@stable",
-        "adodb/adodb-php": "5.*",
+        "adodb/adodb-php": ">=5.19",
         "jamiebicknell/Sparkline": "1.*",
         "league/oauth2-client": "@stable"
     },


### PR DESCRIPTION
Trying to fix this issue: https://bugs.flyspray.org/2189
when an old adodb (e.g. adodb5.04) as php-extension is installed. 

Maybe not solve the issue itself , but lets try. it..