### PR TITLE
use hash_equals and a note to avoid unsalted hashing methods

### DIFF
--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -624,28 +624,31 @@ class Flyspray
         return $db->FetchRow($sql);
     } // }}}
     //  {{{
-    /**
-     * Crypt a password with the method set in the configfile
-     * @param string $password
-     * @access public static
-     * @return string
-     * @version 1.0
-     */
-    public static function cryptPassword($password)
-    {
-        global $conf;
-        $pwcrypt = strtolower($conf['general']['passwdcrypt']);
+  /**
+   * Crypt a password with the method set in the configfile
+   * @param string $password
+   * @access public static
+   * @return string
+   * @version 1.0
+   */
+  public static function cryptPassword($password)
+  {
+	global $conf;
+	$pwcrypt = strtolower($conf['general']['passwdcrypt']);
 
-        if ($pwcrypt == 'sha1') {
-            return sha1($password);
-        } elseif ($pwcrypt == 'md5') {
-			return md5($password);
-		} elseif ($pwcrypt == 'sha512') {
-			return hash('sha512', $password);
-        } else {
-            return crypt($password);
-        }
-    } // }}}
+	# sha1, md5, sha512 are unsalted, hashing methods, not suited for storing passwords anymore.
+	# Use crypt(), that adds random salt, customizable rounds and customizable hashing algorithms.
+	if ($pwcrypt == 'sha1') {
+		return sha1($password);
+	} elseif ($pwcrypt == 'md5') {
+		return md5($password);
+	} elseif ($pwcrypt == 'sha512') {
+		return hash('sha512', $password);
+	} else {
+		return crypt($password);
+	}
+  } // }}}
+
     // {{{
     /**
      * Check if a user provided the right credentials
@@ -682,23 +685,25 @@ class Flyspray
             return 0;
         }
 
-        if( $method != 'ldap' ){
-        //encrypt the password with the method used in the db
-        switch (strlen($auth_details['user_pass'])) {
-            case 40:
-                $password = sha1($password);
-                break;
-			case 32:
-				$password = md5($password);
-				break;
-			case 128:
-				$password = hash('sha512',$password);
-				break;
-            default:
-                $password = crypt($password, $auth_details['user_pass']); //using the salt from db
-                break;
-        }
-        }
+	if( $method != 'ldap' ){
+		// encrypt the password with the method used in the db
+		switch (strlen($auth_details['user_pass'])) {
+		# detecting passwords stored with old unsalted hashing methods: sha1,md5,sha512
+		case 40:
+			$pwhash = sha1($password);
+			break;
+		case 32:
+			$pwhash = md5($password);
+			break;
+		case 128:
+			$pwhash = hash('sha512', $password);
+			break;
+		default:
+			$pwhash = crypt($password, $auth_details['user_pass']); // user_pass contains algorithm, rounds, salt
+			break;
+		}
+	}
+
         if ($auth_details['lock_until'] > 0 && $auth_details['lock_until'] < time()) {
             $db->Query('UPDATE {users} SET lock_until = 0, account_enabled = 1, login_attempts = 0
                            WHERE user_id = ?', array($auth_details['user_id']));
@@ -706,15 +711,19 @@ class Flyspray
             $_SESSION['was_locked'] = true;
         }
 
-        // skip password check if the user is using oauth
-        if($method == 'oauth'){
-            $pwOk = true;
-        } elseif( $method == 'ldap'){
-            $pwOk = Flyspray::checkForLDAPUser($username, $password);
-        }else{
-            // Compare the crypted password to the one in the database
-            $pwOk = ($password == $auth_details['user_pass']);
-        }
+	// skip password check if the user is using oauth
+	if($method == 'oauth'){
+		$pwOk = true;
+	} elseif( $method == 'ldap'){
+		$pwOk = Flyspray::checkForLDAPUser($username, $password);
+	} else{
+		// Compare the crypted password to the one in the database
+		if( function_exists('hash_equals') ){
+			$pwOk = hash_equals($pwhash, $auth_details['user_pass']);
+		} else{
+			$pwOk = ($pwhash == $auth_details['user_pass']);
+		}
+	}
 
         // Admin users cannot be disabled
         if ($auth_details['group_id'] == 1 /* admin */ && $pwOk) {


### PR DESCRIPTION
The current possible values for config param passwdcrypt 'md5', 'sha1' and 'sha512' are unsalted hashing methods.
They should not be used for hashing passwords.

It does NOT mean that they are config parameters for the crypt() function! For that there are the constants CRYPT_MD5, CRYPT_BLOWFISH, CRYPT_SHA512, ... see http://php.net/manual/en/function.crypt.php

Future: Maybe setting 'passwdcrypt' config value will be deprecated or removed and other config names are set that are not so ambiguous. This will not effect existing oldtype stored password hashes, they are detected by their typical stored character length.

Future: Maybe the hashes get automatically converted to stronger/modern methods when the user logs in the next time and provides the raw password to Flyspray.