### PR TITLE
review dokuwikitoolbar and a wiki-cheatsheet

### DIFF
--- a/plugins/dokuwiki/dokuwiki_formattext.inc.php
+++ b/plugins/dokuwiki/dokuwiki_formattext.inc.php
@@ -97,7 +97,8 @@ class dokuwiki_TextFormatter
         $return .= '</textarea>';
         return $return;
     }
-    /**
+
+	/**
 	 * Displays a toolbar for formatting text in the DokuWiki Syntax
 	 * Uses Javascript
 	 *
@@ -105,51 +106,76 @@ class dokuwiki_TextFormatter
 	 */
 	static function getDokuWikiToolbar( $textareaId ) {
 		global $conf, $baseurl;
-	
-		return '<a
-tabindex="-1" title="'.eL('editorbold').'" href="javascript:void(0);" onclick="surroundText(\'**\', \'**\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/format-text-bold.png" alt="Bold" border="0" /></a><a
-tabindex="-1" title="'.eL('editoritalic').'" href="javascript:void(0);" onclick="surroundText(\'//\', \'//\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/format-text-italic.png" alt="Italicized" border="0" /></a><a
-tabindex="-1" title="'.eL('editorunderline').'" href="javascript:void(0);" onclick="surroundText(\'__\', \'__\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/format-text-underline.png" alt="Underline" border="0" /></a><a
-tabindex="-1" title="'.eL('editorstrikethrough').'" href="javascript:void(0);" onclick="surroundText(\'&lt;del&gt;\', \'&lt;/del&gt;\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/format-text-strikethrough.png" alt="Strikethrough" border="0" /></a>
-<img src="'.$baseurl.'plugins/dokuwiki/img/divider.gif" align="bottom" alt="|" style="margin: 0 3px 0 3px;" />
-			
-			<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'======\', \'======\', \''.$textareaId.'\'); return false;">
-			<img title="Level 1 Headline" src="'.$baseurl.'plugins/dokuwiki/img/h1.gif" width="23" height="22" alt="Heading1" border="0" /></a>
+		$out='';
+		
+		$out.='<a tabindex="-1" title="'.eL('editorbold').'" href="javascript:void(0);" onclick="surroundText(\'**\', \'**\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/format-text-bold.png" alt="Bold" /></a>';
+		$out.='<a tabindex="-1" title="'.eL('editoritalic').'" href="javascript:void(0);" onclick="surroundText(\'//\', \'//\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/format-text-italic.png" alt="Italics" /></a>';
+		$out.='<a tabindex="-1" title="'.eL('editorunderline').'" href="javascript:void(0);" onclick="surroundText(\'__\', \'__\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/format-text-underline.png" alt="Underline" /></a>';
+		$out.='<a tabindex="-1" title="'.eL('editorstrikethrough').'" href="javascript:void(0);" onclick="surroundText(\'&lt;del&gt;\', \'&lt;/del&gt;\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/format-text-strikethrough.png" alt="Strikethrough" /></a>';
+		$out.='<img src="'.$baseurl.'plugins/dokuwiki/img/divider.gif" align="bottom" alt="|" style="margin: 0 3px 0 3px;" />';
+		$out.='<a tabindex="-1" title="'.eL('editorh1').'" href="javascript:void(0);" onclick="surroundText(\'======\', \'======\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/h1.gif" width="23" height="22" alt="H1" /></a>';
+		$out.='<a tabindex="-1" title="'.eL('editorh2').'" href="javascript:void(0);" onclick="surroundText(\'=====\', \'=====\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/h2.gif" width="23" height="22" alt="H2" /></a>';
+		$out.='<a tabindex="-1" title="'.eL('editorh3').'" href="javascript:void(0);" onclick="surroundText(\'====\', \'====\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/h3.gif" width="23" height="22" alt="H3" /></a>';
+		$out.='<img title="Divider" src="'.$baseurl.'plugins/dokuwiki/img/divider.gif" alt="|" style="margin: 0 3px 0 3px;" />';
 
-			<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'=====\', \'=====\', \''.$textareaId.'\'); return false;">
-			<img title="Level 2 Headline" src="'.$baseurl.'plugins/dokuwiki/img/h2.gif" width="23" height="22" alt="Heading2" border="0" /></a>
+		/* hide embed syntax until the 'fetch.php issue' is solved or an alternative is implemented
+		$out.='<a tabindex="-1" title="'.eL('editorimage').'" href="javascript:void(0);" onclick="surroundText(\'&#123;&#123;http://\', \'&#125;&#125;\', \''.$textareaId.'\'); return false;">
+			<img src="'.$baseurl.'plugins/dokuwiki/img/image-x-generic.png" alt="image" /></a>';
+		*/
 
-			<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'====\', \'====\', \''.$textareaId.'\'); return false;">
-			<img title="Level 3 Headline" src="'.$baseurl.'plugins/dokuwiki/img/h3.gif" width="23" height="22" alt="Heading3" border="0" /></a>
-			
-			<img title="Divider" src="'.$baseurl.'plugins/dokuwiki/img/divider.gif" alt="|" style="margin: 0 3px 0 3px;" />
-			
-			<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'&#123;&#123;http://\', \'&#125;&#125;\', \''.$textareaId.'\'); return false;">
-				<img src="'.$baseurl.'plugins/dokuwiki/img/image-x-generic.png" alt="Insert Image" title="Insert Image" border="0" /></a>
-			
-			<a tabindex="-1" href="javascript:void(0);" onclick="replaceText(\'\n  * \', \''.$textareaId.'\'); return false;">
-				<img src="'.$baseurl.'plugins/dokuwiki/img/ul.gif" width="23" height="22" alt="Insert List" title="Insert List" border="0" /></a>
-			<a tabindex="-1" href="javascript:void(0);" onclick="replaceText(\'\n  - \', \''.$textareaId.'\'); return false;">
-				<img src="'.$baseurl.'plugins/dokuwiki/img/ol.gif" width="23" height="22" alt="Insert List" title="Insert List" border="0" /></a>
-			<a tabindex="-1" href="javascript:void(0);" onclick="replaceText(\'----\', \''.$textareaId.'\'); return false;">
-				<img src="'.$baseurl.'plugins/dokuwiki/img/hr.gif" width="23" height="22" alt="Horizontal Rule" title="Horizontal Rule" border="0" /></a>
+		$out.='<a tabindex="-1" title="'.eL('editorunorderedli').'" href="javascript:void(0);" onclick="replaceText(\'\n  * \', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/ul.gif" width="23" height="22" alt="ul" /></a>';
+		$out.='<a tabindex="-1" title="'.eL('editororderedli').'" href="javascript:void(0);" onclick="replaceText(\'\n  - \', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/ol.gif" width="23" height="22" alt="ol" /></a>';
+		$out.='<a tabindex="-1" title="'.eL('editorhorizontalrule').'" href="javascript:void(0);" onclick="replaceText(\'----\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/hr.gif" width="23" height="22" alt="hr" /></a>';
+		$out.='<img src="'.$baseurl.'plugins/dokuwiki/img/divider.gif" alt="|" style="margin: 0 3px 0 3px;" />';
+		$out.='<a tabindex="-1" title="'.eL('editorlink').'" href="javascript:void(0);" onclick="surroundText(\'[[http://example.com|External Link\', \']]\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/text-html.png" alt="Link" /></a>';
+
+		/* emailicon for a generic link and a globe for today ftp is a bit unpopular: seems not the most important button/syntax on flyspray's default dokuwiki toolbar
+		$out.='<a tabindex="-1" title="Insert Email" href="javascript:void(0);" onclick="surroundText(\'[[\', \']]\', \''.$textareaId.'\'); return false;">
+			<img src="'.$baseurl.'plugins/dokuwiki/img/email.png" alt="Insert Email" border="0" /></a>';
+		$out.='<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'[[ftp://\', \']]\', \''.$textareaId.'\'); return false;">
+			<img src="'.$baseurl.'plugins/dokuwiki/img/network.png" alt="Insert FTP Link" title="Insert FTP Link" border="0" /></a>';
 				
-			<img src="'.$baseurl.'plugins/dokuwiki/img/divider.gif" alt="|" style="margin: 0 3px 0 3px;" />
-			
-			<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'[[http://example.com|External Link\', \']]\', \''.$textareaId.'\'); return false;">
-				<img src="'.$baseurl.'plugins/dokuwiki/img/text-html.png" alt="Insert Hyperlink" title="Insert Hyperlink" border="0" /></a>					
-			<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'[[\', \']]\', \''.$textareaId.'\'); return false;">
-				<img src="'.$baseurl.'plugins/dokuwiki/img/email.png" alt="Insert Email" title="Insert Email" border="0" /></a>
-			<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'[[ftp://\', \']]\', \''.$textareaId.'\'); return false;">
-				<img src="'.$baseurl.'plugins/dokuwiki/img/network.png" alt="Insert FTP Link" title="Insert FTP Link" border="0" /></a>
-				
-			<img src="'.$baseurl.'plugins/dokuwiki/img/divider.gif" alt="|" style="margin: 0 3px 0 3px;" />
-			
-			<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'<code>\', \'</code>\', \''.$textareaId.'\'); return false;">
-			<img src="'.$baseurl.'plugins/dokuwiki/img/source.png" alt="Insert Code" title="Insert Code" border="0" /></a>
-			<a tabindex="-1" href="javascript:void(0);" onclick="surroundText(\'<code php>\', \'</code>\', \''.$textareaId.'\'); return false;">
-			<img src="'.$baseurl.'plugins/dokuwiki/img/source_php.png" alt="Insert Code" title="Insert PHP Code" border="0" /></a>
-		';
+		$out.='<img src="'.$baseurl.'plugins/dokuwiki/img/divider.gif" alt="|" style="margin: 0 3px 0 3px;" />';
+		*/
+		
+		$out.='<a tabindex="-1" title="'.eL('editorcode').'" href="javascript:void(0);" onclick="surroundText(\'<code>\', \'</code>\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/source.png" alt="Code" /></a>';
+		/*
+		$out.='<a tabindex="-1" title="'.eL('editorcodesyntax).'" href="javascript:void(0);" onclick="surroundText(\'<code php>\', \'</code>\', \''.$textareaId.'\'); return false;"><img src="'.$baseurl.'plugins/dokuwiki/img/source_php.png" alt="Code" /></a>';
+		*/
+
+		# IDEA/TODO: list of available languages for syntax highlighting, dropdownlist or cheatsheet similiar to the wikicheatsheet below
+		# IDEA/TODO: smiley selector similiar to the wikicheatsheet below.
+		
+		/*
+		# wikicheatsheet
+		# Maybe move the generic CSS (without $textareaID) to a dokuwiki.css or something like that.
+		$out.='
+<style>
+#'.$textareaId.' {position:relative;}
+.wikicheatsheet { display:inline-block;margin-left:1em;}
+.wikicheatsheet label{ color:#aaa;}
+.wikicheatsheet td { font-family: monospace;}
+.wikicheatsheet div{ display:none;position:absolute;left:1em;background-color:#fff;z-index:10;padding:1em;border:1px solid #ccc;}
+.wikicheatsheet label:hover ~ div{ display:block;}
+</style>';
+
+		$out.='
+<div class="wikicheatsheet">
+<label for="wikicheatsheet_'.$textareaId.'"><i class="fa fa-info-circle fa-2x"></i></label>
+<div id="wikicheatsheet_'.$textareaId.'">
+<table>
+<tbody>
+<tr><th>'.L('editorlink').'</th><td>[[https://www.flyspray.org|Flyspray]]</td></tr>
+<tr><th>'.L('editorquote').'</th><td>&gt; a quote</td></tr>
+<tr><th>'.L('editorcode').'</th><td>&lt;code&gt;preformatted monospace text&lt;code&gt;</td></tr>
+<tr><th>'.L('editorcodesyntax').'</th><td>&lt;code php&gt;echo "Helloworld";&lt;code&gt;</td></tr>
+</tbody>
+</table>
+</div>
+</div>';
+		*/
+		
+		return $out;
 	}
 }
 ?>


### PR DESCRIPTION
- deactivated some seldom used or redundant buttons on the dokuwikitoolbar (1 instead 3 for adding links)
- made the toolbar a bit more flexible to customize
- made texts of the toolbar translatable
- added an idea for having a simple dokuwikicheatsheet when you need it, simply by hovering an "i"nfo-button on the toolbar
