### PR TITLE
Fix empty last edited date and ordering by max_date

### DIFF
--- a/includes/class.backend.php
+++ b/includes/class.backend.php
@@ -1362,10 +1362,10 @@ LEFT JOIN {list_category} lc ON t.product_category = lc.category_id ';
             $select .= ' (SELECT COUNT(vot.vote_id) FROM {votes} vot WHERE vot.task_id = t.task_id) AS num_votes, ';
         }
 
-        $maxdatesql = ' GREATEST((SELECT max(c.date_added) FROM {comments} c WHERE c.task_id = t.task_id), t.date_opened, t.date_closed, t.last_edited_time) ';
+        $maxdatesql = ' GREATEST(COALESCE((SELECT max(c.date_added) FROM {comments} c WHERE c.task_id = t.task_id), 0), t.date_opened, t.date_closed, t.last_edited_time) ';
         $search_for_changes = in_array('lastedit', $visible) || array_get($args, 'changedto') || array_get($args, 'changedfrom');
         if ($search_for_changes) {
-            $select .= ' GREATEST((SELECT max(c.date_added) FROM {comments} c WHERE c.task_id = t.task_id), t.date_opened, t.date_closed, t.last_edited_time) AS max_date, ';
+            $select .= ' GREATEST(COALESCE((SELECT max(c.date_added) FROM {comments} c WHERE c.task_id = t.task_id), 0), t.date_opened, t.date_closed, t.last_edited_time) AS max_date, ';
             $cgroupbyarr[] = 't.task_id';
         }
 


### PR DESCRIPTION
GREATEST() function returns NULL if any argument is NULL (for MySQL only, not for Postgresql)

So, if there is no comment added for a task, a GREATEST(comment.date_added, task.date_opened, task.date_closed, task.last_edited_time) comparison will always return NULL.

The result can be seen in the column "Last edited" which is 'sometimes' empty because the function `tpl_draw_cell` from scripts/index.php:235 `$value = formatDate($task[$indexes[$colname]]);` with a 
`$task['max_date']` as NULL renders an empty string.

Sorting through the latest issue date is also affected.

A way to fix that is to replace the NULL output by 0 with a COALESCE function. 

Above, you can find an out-of-the-fs-box test case:

> Assuming you have fs_comments and fs_tasks tables (prefix=fs_)

``` sql
SELECT 
  GREATEST(
    COALESCE(
      ( SELECT max( c.date_added )
        FROM fs_comments c
        WHERE c.task_id = t.task_id )
      , 0 
    )
    , t.date_opened
    , t.date_closed
    , t.last_edited_time
  ) AS max_date -- comparison

  , t.date_opened
  , t.date_closed
  , t.last_edited_time

FROM `fs_tasks` t

ORDER BY max_date DESC
```

Furthermore, this patch is compatible with MySQL and Postgres, since COALESCE is implemented.
