### PR TITLE
Image transparency color, tab switching class

### DIFF
--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -40,9 +40,9 @@ function resizeImage($file, $max_x, $max_y, $forcePng = false)
 	$newHeight = $height * $scale;
 
 	$img = imagecreatefromstring(file_get_contents($src));
-	$black = imagecolorallocate($img, 0, 0, 0);
+	$transparent = imagecolorallocate($img, 255, 0, 255);
 	$resizedImage = imageCreateTrueColor($newWidth, $newHeight);
-	imagecolortransparent($resizedImage, $black);
+	imagecolortransparent($resizedImage, $transparent);
 	imageCopyResampled($resizedImage, $img, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
 	imageDestroy($img);
 	unlink($src);

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -49,8 +49,8 @@ function showTabById(tabid, noEval) { // {{{
       var links = submenu.getElementsByTagName('a');
       for (i=0; i<links.length; i++) {
         if (links[i].href.match('^.*#'+tabid+'$')) {
-          links[i].className = 'active';
-        } else { links[i].className = ''; }
+          links[i].className += ' active';
+        } else { links[i].className = links[i].className.replace(/ active\b/, ''); }
       }
     }
   }

--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -365,7 +365,7 @@ echo tpl_select(
 </thead>
 <tbody>
 <?php foreach ($tasks as $task):?>
-<tr id="task<?php echo $task['task_id']; ?>" class="severity<?php echo $task['task_severity'];  echo $task['is_closed'] ==1 ? ' closed': '';?>" onmouseover="Show(this,<?php echo $task['task_id']; ?>)" onmouseout="Hide(this, <?php echo $task['task_id']; ?>)">
+<tr id="task<?php echo $task['task_id']; ?>" class="severity<?php echo $task['task_severity'];  echo $task['is_closed'] ==1 ? ' closed': '';?>">
 	<td class="caret"></td>
 	<?php if (!$user->isAnon() && $proj->id !=0): ?>
 	<td class="ttcolumn"><input class="ticktask" type="checkbox" name="ids[]" onclick="BulkEditCheck()" value="<?php echo $task['task_id']; ?>"/></td>
@@ -374,7 +374,9 @@ echo tpl_select(
 	foreach ($visible as $col):
 		if($col == 'progress'):?>
 	<td class="task_progress"><div class="progress_bar_container"><span><?php echo $task['percent_complete']; ?>%</span><div class="progress_bar" style="width:<?php echo $task['percent_complete']; ?>%"></div></div></td>
-		<?php else:
+		<?php elseif ($col == 'summary'):
+			echo tpl_draw_cell($task, $col, "<td class='%s' onmouseover=\"Show(this," . $task['task_id'] . ")\" onmouseout=\"Hide(this, " . $task['task_id'] . ")\">%s</td>");
+		else:
 		echo tpl_draw_cell($task, $col);
 		endif;
 	endforeach;


### PR DESCRIPTION
These are a couple small things I've fixed in my local install.

Uploading an avatar that contains black masks that and creates ugly visual holes, so I switched the mask color to a more traditional one that is less likely to appear in images.

The tab switch class change here is more explicit.  I'm running a custom theme that is a complete copy of CleanFS, where I've used FontAwesome to put icons on the tabs by adding `fa-*` classes to the tab links.  There are several changes in this theme which I hope to backport into CleanFS soon as pull requests.