### PR TITLE
Active tab class switching

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -49,8 +49,8 @@ function showTabById(tabid, noEval) { // {{{
       var links = submenu.getElementsByTagName('a');
       for (i=0; i<links.length; i++) {
         if (links[i].href.match('^.*#'+tabid+'$')) {
-          links[i].className = 'active';
-        } else { links[i].className = ''; }
+          links[i].className += ' active';
+        } else { links[i].className = links[i].className.replace(/ active\b/, ''); }
       }
     }
   }


### PR DESCRIPTION
Changed add/remove of active class on tabs to be more explicit, which is safer for themes that may have added other classes to tabs (ie, FontAwesome).