### PR TITLE
fix FS#2330

### DIFF
--- a/scripts/index.php
+++ b/scripts/index.php
@@ -427,7 +427,7 @@ function export_task_list()
 
         usort($tasks, "do_cmp");
 
-        $outfile = str_replace(' ', '_', $tasks[0]['project_title']).'_'.date("Y-m-d").'.csv';
+        $outfile = str_replace(' ', '_', $proj->prefs['project_title']).'_'.date("Y-m-d").'.csv';
 
         #header('Content-Type: application/csv');
         header('Content-Type: text/csv');


### PR DESCRIPTION
and build the appropriate .csv filename also for the 'all projects' tasklist when doing csv export from a task search.