### PR TITLE
fix a PHP7.1 notice: A non well formed numeric value encountered ..

### DIFF
--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -95,14 +95,14 @@ class Flyspray
                 continue;
             }
 
-            $val = trim($val);
             $last = strtolower($val{strlen($val)-1});
+            $val = trim($val, 'gGmMkK');
             switch ($last) {
                 // The 'G' modifier is available since PHP 5.1.0
                 case 'g':
-                    $val *= 1024;
+                    $val *= 1024*1024*1024;
                 case 'm':
-                    $val *= 1024;
+                    $val *= 1024*1024;
                 case 'k':
                     $val *= 1024;
             }

--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -100,9 +100,9 @@ class Flyspray
             switch ($last) {
                 // The 'G' modifier is available since PHP 5.1.0
                 case 'g':
-                    $val *= 1024*1024*1024;
+                    $val *= 1024;
                 case 'm':
-                    $val *= 1024*1024;
+                    $val *= 1024;
                 case 'k':
                     $val *= 1024;
             }


### PR DESCRIPTION
$val initially contains either an integer, or a string like 128M or 512K.
Therefore, to obtain the value in octets we need to

  1) get the last character and store it
  2) trim it from $val to get a correct number
  3) multiply $val by the amount obtained through the switch control

That's what the patch does.