### PR TITLE
set baseurl early for js callbacks

### DIFF
--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -21,7 +21,9 @@ if (isset($conf['general']['force_baseurl']) && $conf['general']['force_baseurl'
         if (!$webdir) {
             $webdir = dirname($_SERVER['SCRIPT_NAME']);
         }
-        if (substr($webdir, -9) == 'index.php') {
+        if(substr($webdir, -13) == '/js/callbacks'){
+            $webdir = dirname(dirname($webdir));
+        } elseif (substr($webdir, -9) == 'index.php') {
             $webdir = dirname($webdir);
         }
     }

--- a/js/callbacks/gethistory.php
+++ b/js/callbacks/gethistory.php
@@ -10,7 +10,6 @@ header('Content-type: text/html; charset=utf-8');
 
 require_once('../../header.php');
 require_once('../../includes/events.inc.php');
-$baseurl = dirname(dirname($baseurl)) .'/' ;
 
 // Initialise user
 if (Cookie::has('flyspray_userid') && Cookie::has('flyspray_passhash')) {

--- a/js/callbacks/getsearches.php
+++ b/js/callbacks/getsearches.php
@@ -9,7 +9,6 @@ define('IN_FS', true);
 header('Content-type: text/html; charset=utf-8');
 
 require_once('../../header.php');
-$baseurl = dirname(dirname($baseurl)) .'/' ;
 
 // Initialise user
 if (Cookie::has('flyspray_userid') && Cookie::has('flyspray_passhash')) {

--- a/js/callbacks/quickedit.php
+++ b/js/callbacks/quickedit.php
@@ -7,8 +7,6 @@ header('Content-type: text/html; charset=utf-8');
 require_once('../../header.php');
 global $proj, $fs;
 
-$baseurl = dirname(dirname($baseurl)) .'/' ;
-
 if (Cookie::has('flyspray_userid') && Cookie::has('flyspray_passhash')) {
     $user = new User(Cookie::val('flyspray_userid'));
     $user->check_account_ok();

--- a/js/callbacks/testemail.php
+++ b/js/callbacks/testemail.php
@@ -7,8 +7,6 @@ header('Content-type: text/html; charset=utf-8');
 require_once('../../header.php');
 global $proj, $fs;
 
-$baseurl = dirname(dirname($baseurl)) .'/' ;
-
 if (Cookie::has('flyspray_userid') && Cookie::has('flyspray_passhash')) {
   $user = new User(Cookie::val('flyspray_userid'));
   $user->check_account_ok();


### PR DESCRIPTION
fixing $baseurl after including the header.php is too late, because some depending constants are effected by them (DOKU_BASE) too, that are set earlier. example: image url for dokuwiki smileys in the gethistory callback.