### PR TITLE
Active tab class switching improvement

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -49,8 +49,8 @@ function showTabById(tabid, noEval) { // {{{
       var links = submenu.getElementsByTagName('a');
       for (i=0; i<links.length; i++) {
         if (links[i].href.match('^.*#'+tabid+'$')) {
-          links[i].className += ' active';
-        } else { links[i].className = links[i].className.replace(/ active\b/, ''); }
+          links[i].className = links[i].className.replace(/ active\b/g, '') + ' active';
+        } else { links[i].className = links[i].className.replace(/ active\b/g, ''); }
       }
     }
   }


### PR DESCRIPTION
When switching tabs, remove all instances of the active class from all tab links' className before appending ' active' to the target link.  Solves the issue introduced in pull request #614: the active class was getting added multiple times, but only the final instance got removed.

FYI: 'CSS-only' tab switching doesn't seem possible in the strictest sense.  There are two popular approaches considered 'CSS-only':

- Replace tab links with radio input+label pairs and use CSS selectors to show the correct panel; all the implementations I've seen rely on ~ selectors, which require the radios and panels to be siblings (uglier DOM structure).  It may be possible to use more complex attribute selectors instead, and maintain the current tabs DOM structure.
- Use the target URL fragment to indicate the active tab; most implementations rely on JS to prevent the window from jumping up and down.