### PR TITLE
index.php: workaround PHP bug 43225

### DIFF
--- a/scripts/index.php
+++ b/scripts/index.php
@@ -369,6 +369,25 @@ function do_cmp($a, $b)
    return ($a[ $orderby ] > $b[ $orderby ]) ? -1 : 1;
 }
 
+function my_fputcsv($handle, $fields)
+{
+  $out = array();
+
+  foreach ($fields as $field) {
+    if (empty($field)) {
+      $out[] = '';
+    }
+    elseif (preg_match('/^\d+(\.\d+)?$/', $field)) {
+      $out[] = $field;
+    }
+    else {
+      $out[] = '"' . preg_replace('/"/', '""', $field) . '"';
+    }
+  }
+
+  return fwrite($handle, implode(',', $out) . "\n");
+}
+
 
 /*********************************************
 *
@@ -481,7 +500,7 @@ function export_task_list()
                         // ($user->perms('view_current_effort_done') && $proj->prefs['use_effort_tracking']) ? $task['effort'] : '',
                         $task['detailed_desc']
                 );
-                fputcsv($output, $row);
+                my_fputcsv($output, $row);
         }
         fclose($output);
         exit();


### PR DESCRIPTION
PHP's implementation of fputcsv() fails to properly escape CSV quote
characters preceeded by a backslash. An input string like `test \" test`
is converted to `"test \" test"` instead of the expected `"test \"" test"`
result.

Due to this issue, it is impossible to properly parse the generated
task CSV export list.

Work around the problem by utilizing a custom CSV formatting function
instead which properly escapes quote characters.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>