### PR TITLE
fix FS#2490 lostpw for long usernames

### DIFF
--- a/themes/CleanFS/templates/lostpw.step1.tpl
+++ b/themes/CleanFS/templates/lostpw.step1.tpl
@@ -1,10 +1,10 @@
 <h3><?php echo Filters::noXSS(L('lostpw')); ?></h3>
 <div class="box">
     <p><?php echo Filters::noXSS(L('lostpwexplain')); ?></p>
-    <?php echo tpl_form(Filters::noXSS(CreateUrl('lostpw'))); ?>
+    <?php echo tpl_form(Filters::noXSS(createUrl('lostpw'))); ?>
         <p><b><?php echo Filters::noXSS(L('username')); ?></b>
         <input type="hidden" name="action" value="lostpw.sendmagic" />
-        <input class="text" type="text" value="<?php echo Filters::noXSS(Req::val('user_name')); ?>" name="user_name" size="20" maxlength="20" />
+        <input class="text" type="text" value="<?php echo Filters::noXSS(Req::val('user_name')); ?>" name="user_name" size="20" maxlength="32" />
         <button type="submit"><?php echo Filters::noXSS(L('sendlink')); ?></button>
         </p>
     </form>


### PR DESCRIPTION
usernames up to 32 chars allowed, so it should be possible for that users to use the password forgotten functionality. :-)