### PR TITLE
Fix for error using a non existing ticket ID

### DIFF
--- a/includes/class.database.php
+++ b/includes/class.database.php
@@ -283,7 +283,7 @@ class Database
     public function fetchOne($result)
     {
         $row = $this->fetchRow($result);
-        return (count($row) ? $row[0] : '');
+        return (isset($row[0]) ? $row[0] : '');
     }
 
     /**


### PR DESCRIPTION
If you try to open the detailed view of a non existing ticket with PHP >= 7.2.x by changing the ID by hand, a non-countable warning occurs (http://php.net/manual/en/migration72.incompatible.php). This fix should handle that. 