### PR TITLE
compare can_self_register() and can_register()

### DIFF
--- a/includes/class.user.php
+++ b/includes/class.user.php
@@ -402,16 +402,22 @@ class User
     {
     }
 
+    /**
+    * tests if current configuration allows a guest user to register - without email verification code
+    */
     public function can_self_register()
     {
         global $fs;
-        return $this->isAnon() && !$fs->prefs['spam_proof'] && $fs->prefs['anon_reg'] && !$fs->prefs['only_oauth_reg'];
+        return $this->isAnon() && $fs->prefs['anon_reg'] && !$fs->prefs['only_oauth_reg'] && !$fs->prefs['spam_proof'] ;
     }
 
+    /**
+    * tests if current configuration allows a guest user to register - with email verification code
+    */
     public function can_register()
     {
         global $fs;
-        return $this->isAnon() && !$fs->prefs['need_approval'] && $fs->prefs['spam_proof'] && $fs->prefs['anon_reg'] && !$fs->prefs['only_oauth_reg'];
+        return $this->isAnon() && $fs->prefs['anon_reg'] && !$fs->prefs['only_oauth_reg'] && $fs->prefs['spam_proof'] && !$fs->prefs['need_approval'] ;
     }
 
     public function can_open_task($proj)


### PR DESCRIPTION
aligned the compared preference values in same order to make the differences between can_register() and can_self_register() more obvious. The naming of this 2 methods and the preference 'spam_proof' is probably not good, so added at least some documentation of what it really means currently. Also 'need_approval' (by an admin) setting is in my opinion independent of user email verification setting ('spam_proof' *sic*), so this is probably not the last change on this topic.