### PR TITLE
highlight advanced search input fields

### DIFF
--- a/themes/CleanFS/templates/common.datepicker.tpl
+++ b/themes/CleanFS/templates/common.datepicker.tpl
@@ -1,7 +1,7 @@
 <?php if ($label): ?>
 <label for="<?php echo Filters::noXSS($name); ?>"><?php echo Filters::noXSS($label); ?></label>
 <?php endif; ?>
-<input id="<?php echo Filters::noXSS($name); ?>" type="text" class="text" size="10" name="<?php echo Filters::noXSS($name); ?>" value="<?php echo Filters::noXSS($date); ?>" />
+<input id="<?php echo Filters::noXSS($name); ?>" type="text" class="text" size="10" name="<?php echo Filters::noXSS($name); ?>" placeholder=" " value="<?php echo Filters::noXSS($date); ?>" />
 
 <a class="datelink" href="#" id="<?php echo Filters::noXSS($name); ?>dateview">
   <!--<img src="<?php echo Filters::noXSS($this->get_image('x-office-calendar')); ?>" alt="<?php echo Filters::noXSS(L('selectdate')); ?>" />-->

--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -268,13 +268,13 @@ echo tpl_select(
                 <fieldset class="advsearch_users">
                     <legend><?php echo Filters::noXSS(L('users')); ?></legend>
                     <label class="default multisel" for="opened"><?php echo Filters::noXSS(L('openedby')); ?></label>
-                    <?php echo tpl_userselect('opened', Get::val('opened'), 'opened'); ?>
+                    <?php echo tpl_userselect('opened', Get::val('opened'), 'opened', array('placeholder'=>' ')); ?>
 
-		    <?php if (!$filter || in_array('assignedto', $fields)) { ?>
+		<?php if (!$filter || in_array('assignedto', $fields)) { ?>
                     <label class="default multisel" for="dev"><?php echo Filters::noXSS(L('assignedto')); ?></label>
-                    <?php echo tpl_userselect('dev', Get::val('dev'), 'dev'); } ?>
+                    <?php echo tpl_userselect('dev', Get::val('dev'), 'dev', array('placeholder'=>' ')); } ?>
                     <label class="default multisel" for="closed"><?php echo Filters::noXSS(L('closedby')); ?></label>
-                    <?php echo tpl_userselect('closed', Get::val('closed'), 'closed'); ?>
+                    <?php echo tpl_userselect('closed', Get::val('closed'), 'closed', array('placeholder'=>' ')); ?>
                 </fieldset>
 
                 <fieldset class="advsearch_dates">

--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -70,7 +70,7 @@
 <?php $filter = false; if($proj->id > 0) { $filter = true; $fields = explode( ' ', $proj->prefs['visible_fields'] );} ?>
 <form id="search" action="<?php echo Filters::noXSS($baseurl); ?>index.php" method="get">
   <button id="searchthisproject" type="submit"><?php echo Filters::noXSS(L('searchthisproject')); ?></button>
-  <input class="text" id="searchtext" name="string" type="text" size="20"
+  <input class="text" id="searchtext" name="string" type="text" size="20" placeholder=" "
    maxlength="100" value="<?php echo Filters::noXSS(Get::val('string')); ?>" accesskey="q"/>
   <input type="hidden" name="project" value="<?php echo Filters::noXSS(Get::num('project', $proj->id)); ?>"/>
   <input type="hidden" name="do" value="index"/>

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -81,6 +81,19 @@ body a.button.positive, body button.positive {
         color:#666;
 }
 
+/*
+ highlight advanced search fields that have input 
+ no pure CSS styling of options of multiselects possible (it was back in time in some web browsers, a shame!)
+*/
+#search #searchtext:not(:placeholder-shown),
+#search #duedatefrom:not(:placeholder-shown), #search #duedateto:not(:placeholder-shown),
+#search #changedfrom:not(:placeholder-shown), #search #changedto:not(:placeholder-shown),
+#search #openedfrom:not(:placeholder-shown), #search #openedto:not(:placeholder-shown),
+#search #closedfrom:not(:placeholder-shown), #search #closedto:not(:placeholder-shown),
+#search input.users:not(:placeholder-shown) {
+    background-color: #ff9;
+}
+
 /* end default Flyspray color scheme */
 
 body {


### PR DESCRIPTION
When working with the advanced task search, a yet existing value from a previous search in a text input field can be quickly overseen and the user may wonder why the search result is smaller than expected. By highlighting that text input fields the user immediately sees the filled search criteria. (when the advanced search form is visible, ok ..)