### PR TITLE
Added rules for Visual Studio Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ composer.phar
 /avatars/*
 /lang/*.php.bak
 /lang/*.php.safe
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json


### PR DESCRIPTION
I saw that there's still a rule for the old PHPEdit so I thought it'd be useful to add relevant rules for VSCode not only because I use it myself but also because it's quite popular right now.
Rules taken from the "official" repository: https://github.com/github/gitignore