### PR TITLE
svg activity sparklines

### DIFF
--- a/scripts/activity.php
+++ b/scripts/activity.php
@@ -8,7 +8,7 @@ if (!defined('IN_FS')) {
     die('Do not access this file directly.');
 }
 
-$data='';
+$data=array();
 
 # Project Graph
 if ((Get::has('project_id') && Get::val('graph', 'project') == 'project')) {
@@ -21,13 +21,12 @@ if ((Get::has('project_id') && Get::val('graph', 'project') == 'project')) {
 		//look 30 + days and if found scale
 		$projectCheck = Project::getActivityProjectCount($sixtyone_days, $thirtyone_days, Get::num('project_id'));
 
-		if($projectCheck > 0) {
+		if ($projectCheck > 0) {
 			$data = Project::getDayActivityByProject($sixtyone_days, $end, Get::num('project_id'));
 		} else {
 			$data = Project::getDayActivityByProject($thirtyone_days, $end, Get::num('project_id'));
 		}
 
-		$data = implode(',', $data);
 	} else {
 		# and make the zero-line 'invisible'
 		$_GET['line']='fff';
@@ -49,7 +48,6 @@ if ((Get::has('project_id') && Get::val('graph', 'project') == 'project')) {
 			$data = User::getDayActivityByUser($thirtyone_days, $end, Get::num('project_id'), Get::num('user_id'));
 		}
 
-		$data = implode(',', $data);
 	} else {
 		# and make the zero-line 'invisible'
 		$_GET['line']='fff';
@@ -59,8 +57,43 @@ if ((Get::has('project_id') && Get::val('graph', 'project') == 'project')) {
 	$_GET['line']='fff';
 }
 
-// Not pretty but gets the job done.
-$_SERVER['QUERY_STRING'] = 'size=160x25&data='. $data;
-$_GET['size']            = '160x25';
-$_GET['data']            = $data;
-require dirname(__DIR__) . '/vendor/jamiebicknell/Sparkline/sparkline.php';
+$height=25;
+$width=160;
+if (extension_loaded('gd')) {
+	// Not pretty but gets the job done.
+	$_SERVER['QUERY_STRING'] = 'size='.$width.'x'.$height.'&data='.$data;
+	$_GET['size']            = $width.'x'.$height;
+	$_GET['data']            = implode(',', $data);
+	require dirname(__DIR__) . '/vendor/jamiebicknell/Sparkline/sparkline.php';
+} else {
+	# maybe svg gets the default as it is more versatile than just sparklines with gd
+
+	header('Content-Type: image/svg+xml');
+	# do we need that really?
+	/*echo '<?xml version="1.0" standalone="no"?>'; */
+	#echo '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">';
+	echo '<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="'.$width.'" height="'.$height.'" viewbox="0 0 '.$width.' '.$height.'">';
+	if (count($data)<1) {
+		echo '<!-- no data --></svg>';
+		exit;
+	}
+	$max=max($data); # TODO: limit influence of unusual high activity spikes, or logarithm scales
+	if ($max<1) {
+		$max=1;
+	}
+	$days=count($data);
+	# just to be sure                                     
+	if ($days<1) {
+		$days=1;
+	}
+	$path='';
+	$tick=0;
+	foreach ($data as $d){
+		$tick++;
+		$path.=' L'.$tick.','.($height*$d/$max);
+	}
+	$path.=' L'.$tick.',0';
+	echo "\n".'<path d="M0,0 '.$path.'" stroke="#369" stroke-width="'.(2*$days/$width).'" fill="none" transform="translate(0,'.$height.') scale('.($width/$days).',-1)"/>';
+	echo '</svg>';
+	exit;
+}


### PR DESCRIPTION
Use svg as fallback when gd extension is not installed.

But maybe replace the sparkline image generation in future completely as svg is more flexible to use ...

... and travis-ci still does not like the dependency to jamiebicknell/Sparkline ...