### PR TITLE
feat: make ldap configurable

### DIFF
--- a/includes/class.backend.php
+++ b/includes/class.backend.php
@@ -705,6 +705,9 @@ abstract class Backend
                 $newuser[0][$email] = array('recipient' => $email, 'lang' => $fs->prefs['lang_code']);
             }
 
+	    if(is_null($notify)) {
+		    $notify = new Notifications();
+	    }
             // Notify the appropriate users
 			if ($fs->prefs['notify_registration']) {
                 $notify->create(NOTIFY_NEW_USER, null,

--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -791,54 +791,68 @@ ORDER BY MIN(u.account_enabled) DESC, MIN(u.user_name) ASC');
 	}
   }
 
-    /**
-     * Check if a user provided the right credentials
-     * @param string $username
-     * @param string $password
-     * @param string $method '', 'oauth', 'ldap', 'native'
-     * @access public static
-     * @return integer user_id on success, 0 if account or user is disabled, -1 if password is wrong
-     * @version 1.0
-     */
-    public static function checkLogin($username, $password, $method = 'native')
-    {
-        global $db;
 
-		$email_address = $username;  //handle multiple email addresses
-		$temp = $db->query("SELECT id FROM {user_emails} WHERE email_address = ?",$email_address);
-		$user_id = $db->fetchRow($temp);
-		$user_id = $user_id["id"];
-
+	public static function fetchAuthDetails($username, $method = 'native')
+	{
+		global $db;
+		if($method === 'ldap') {
+			$user_id = -42;
+		} else {
+			// handle multiple email addresses
+			$temp = $db->query("SELECT id FROM {user_emails} WHERE email_address = ?", $username);
+			$user_id = $db->fetchRow($temp);
+			$user_id = $user_id["id"];
+		}
 		$result = $db->query("SELECT  uig.*, g.group_open, u.account_enabled, u.user_pass,
-                                        lock_until, login_attempts
-                                FROM  {users_in_groups} uig
-                           LEFT JOIN  {groups} g ON uig.group_id = g.group_id
-                           LEFT JOIN  {users} u ON uig.user_id = u.user_id
-                               WHERE  u.user_id = ? OR u.user_name = ? AND g.project_id = ?
-                            ORDER BY  g.group_id ASC", array($user_id, $username, 0));
-
+		                              lock_until, login_attempts
+		                      FROM  {users_in_groups} uig
+		                      LEFT JOIN  {groups} g ON uig.group_id = g.group_id
+		                      LEFT JOIN  {users} u ON uig.user_id = u.user_id
+		                      WHERE  (u.user_id = ? OR u.user_name = ?) AND g.project_id = ?
+		                      ORDER BY  g.group_id ASC",
+		                     array($user_id, $username, 0));
 		$auth_details = $db->fetchRow($result);
+		if(!$result || !count($auth_details)) {
+			return false;
+		}
+		if ($auth_details['lock_until'] > 0 && $auth_details['lock_until'] < time()) {
+			$db->query('UPDATE {users} SET lock_until = 0, account_enabled = 1, login_attempts = 0
+			            WHERE user_id = ?',
+			           array($auth_details['user_id']));
+			$auth_details['account_enabled'] = 1;
+			$_SESSION['was_locked'] = true;
+		}
+		return $auth_details;
+	}
 
+	/**
+	 * Check if a user provided the right credentials
+	 * @param string $username
+	 * @param string $password
+	 * @param string $method '', 'oauth', 'ldap', 'native'
+	 * @access public static
+	 * @return integer user_id on success, 0 if account or user is disabled, -1 if password is wrong
+	 * @version 1.0
+	 */
+	public static function checkLogin($username, $password, $method = 'native')
+	{
+		$pwok = null;
+		if($method == 'oauth') {
+			// skip password check if the user is using oauth
+			$pwok = true;
+		} elseif($method === 'ldap') {
+			$pwok = Flyspray::checkForLDAPUser($username, $password);
+			if(!$pwok) {
+				return -1;
+			}
+		}
+
+		$auth_details = Flyspray::fetchAuthDetails($username, $method);
 		if($auth_details === false) {
 			return -2;
 		}
-		if(!$result || !count($auth_details)) {
-			return 0;
-		}
 
-        if ($auth_details['lock_until'] > 0 && $auth_details['lock_until'] < time()) {
-            $db->query('UPDATE {users} SET lock_until = 0, account_enabled = 1, login_attempts = 0
-                           WHERE user_id = ?', array($auth_details['user_id']));
-            $auth_details['account_enabled'] = 1;
-            $_SESSION['was_locked'] = true;
-        }
-
-		// skip password check if the user is using oauth
-		if($method == 'oauth'){
-			$pwok = true;
-		} elseif( $method == 'ldap'){
-			$pwok = Flyspray::checkForLDAPUser($username, $password);
-		} else{
+		if(is_null($pwok)) {
 			// encrypt the password with the method used in the db
 			if(substr($auth_details['user_pass'],0,1)!='$' && (
 			           strlen($auth_details['user_pass'])==32
@@ -873,7 +887,7 @@ ORDER BY MIN(u.account_enabled) DESC, MIN(u.user_name) ASC');
 		}
 
 		return ($auth_details['account_enabled'] && $auth_details['group_open']) ? 0 : -1;
-    }
+	}
 
     static public function checkForOauthUser($uid, $provider)
     {
@@ -893,19 +907,26 @@ ORDER BY MIN(u.account_enabled) DESC, MIN(u.user_name) ASC');
     }
 
 	/**
-	* 20150320 just added from provided patch, untested!
-	*/
+	 * Check if a LDAP user exists and binds
+	 * @param string $username
+	 * @param string $password
+	 * @access public static
+	 * @return bool
+	 */
 	public static function checkForLDAPUser($username, $password)
 	{
+		global $conf, $db, $fs;
+
 		# TODO: add to admin settings area, maybe let user set the config at final installation step
-		$ldap_host = 'ldaphost';
-		$ldap_port = '389';
-		$ldap_version = '3';
-		$base_dn = 'OU=SBSUsers,OU=Users,OU=MyBusiness,DC=MyDomain,DC=local';
-		$ldap_search_user = 'ldapuser@mydomain.local';
-		$ldap_search_pass = "ldapuserpass";
-		$filter = "SAMAccountName=%USERNAME%"; // this is for AD - may be different with other setups
-		$username = $username;
+		$ldap_host =        $conf['ldap']['host'];         # ldap.example.com
+		$ldap_port =        $conf['ldap']['port'];         # 389
+		$ldap_version =     $conf['ldap']['version'];      # 3
+		$base_dn =          $conf['ldap']['base_dn'];      # ou=users,dc=example,dc=com
+		$ldap_search_user = $conf['ldap']['search_user'];  #
+		$ldap_search_pass = $conf['ldap']['search_pass'];  #
+		$filter =           $conf['ldap']['filter'];       # uid=%USERNAME%
+		$lf_name =          $conf['ldap']['field_name'] ?? 'cn';
+		$lf_email =         $conf['ldap']['field_email'] ?? 'mail';
 
 		if (strlen($password) == 0){ // LDAP will succeed binding with no password on AD (defaults to anon bind)
 			return false;
@@ -918,8 +939,8 @@ ORDER BY MIN(u.account_enabled) DESC, MIN(u.user_name) ASC');
 		$ldap_bind_pw = empty($ldap_search_pass) ? NULL : $ldap_search_pass;
 		if (!$bindok = @ldap_bind($rs, $ldap_bind_dn, $ldap_search_pass)){
 			// Uncomment for LDAP debugging
-			$error_msg = ldap_error($rs);
-			die("Couldn't bind using ".$ldap_bind_dn."@".$ldap_host.":".$ldap_port." Because:".$error_msg);
+			#$error_msg = ldap_error($rs);
+			#die("Couldn't bind using ".$ldap_bind_dn."@".$ldap_host.":".$ldap_port." Because:".$error_msg);
 			return false;
 		} else{
 			$filter_r = str_replace("%USERNAME%", $username, $filter);
@@ -935,10 +956,31 @@ ORDER BY MIN(u.account_enabled) DESC, MIN(u.user_name) ASC');
 			$ldap_user_dn = $first_user["dn"];
 			// Bind with the dn of the user that matched our filter (only one user should match sAMAccountName or uid etc..)
 			if (!$bind_user = @ldap_bind($rs, $ldap_user_dn, $password)){
-				$error_msg = ldap_error($rs);
-				die("Couldn't bind using ".$ldap_user_dn."@".$ldap_host.":".$ldap_port." Because:".$error_msg);
+				#$error_msg = ldap_error($rs);
+				#die("Couldn't bind using ".$ldap_user_dn."@".$ldap_host.":".$ldap_port." Because:".$error_msg);
 				return false;
 			} else{
+				// Create user if it doesn't exist
+				$result = $db->query("SELECT user_id
+					              FROM {users}
+						      WHERE user_name = ?", array($username));
+				$user_id = $db->fetchRow($result);
+				if (!$result || !$user_id) {
+					$group_in = $fs->prefs['anon_group'];
+					$success  = Backend::create_user(
+						$username,                    // login
+						null,                         // password
+						$first_user[$lf_name][0],     // name
+						'',                           // jabber id
+						$first_user[$lf_email][0],    // email
+						1,                            // notify type
+						(intval(strftime("%z"))/100), // time zone
+						$group_in,                    // group in
+						1);                           // enabled
+					if(!$success) {
+						die('Unable to register new LDAP user');
+					}
+				}
 				return true;
 			}
 		}

--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -925,8 +925,8 @@ ORDER BY MIN(u.account_enabled) DESC, MIN(u.user_name) ASC');
 		$ldap_search_user = $conf['ldap']['search_user'];  #
 		$ldap_search_pass = $conf['ldap']['search_pass'];  #
 		$filter =           $conf['ldap']['filter'];       # uid=%USERNAME%
-		$lf_name =          $conf['ldap']['field_name'] ?? 'cn';
-		$lf_email =         $conf['ldap']['field_email'] ?? 'mail';
+		$lf_name =          isset($conf['ldap']['field_name']) ? $conf['ldap']['field_name'] : 'cn';
+		$lf_email =         isset($conf['ldap']['field_email']) ? $conf['ldap']['field_email'] : 'mail';
 
 		if (strlen($password) == 0){ // LDAP will succeed binding with no password on AD (defaults to anon bind)
 			return false;

--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -812,7 +812,7 @@ ORDER BY MIN(u.account_enabled) DESC, MIN(u.user_name) ASC');
 		                      ORDER BY  g.group_id ASC",
 		                     array($user_id, $username, 0));
 		$auth_details = $db->fetchRow($result);
-		if(!$result || !count($auth_details)) {
+		if(!$result || (is_array($auth_details) && !count($auth_details))) {
 			return false;
 		}
 		if ($auth_details['lock_until'] > 0 && $auth_details['lock_until'] < time()) {

--- a/scripts/authenticate.php
+++ b/scripts/authenticate.php
@@ -20,7 +20,7 @@ if (Req::val('user_name') != '' && Req::val('password') != '') {
     // $username = Backend::clean_username(Req::val('user_name'));
     $username = Req::val('user_name');
     $password = Req::val('password');
-    $method = $conf['general']['auth_method'] ?? 'native';
+    $method = isset($conf['general']['auth_method']) ? $conf['general']['auth_method'] : 'native';
 
     // Run the username and password through the login checker
     $user_id = Flyspray::checkLogin($username, $password, $method);

--- a/scripts/authenticate.php
+++ b/scripts/authenticate.php
@@ -20,9 +20,15 @@ if (Req::val('user_name') != '' && Req::val('password') != '') {
     // $username = Backend::clean_username(Req::val('user_name'));
     $username = Req::val('user_name');
     $password = Req::val('password');
+    $method = $conf['general']['auth_method'] ?? 'native';
 
     // Run the username and password through the login checker
-    if (($user_id = Flyspray::checkLogin($username, $password)) < 1) {
+    $user_id = Flyspray::checkLogin($username, $password, $method);
+    if($method === 'ldap' && $user_id < 1) {
+        // Recheck with native method if LDAP
+        $user_id = Flyspray::checkLogin($username, $password, 'native');
+    }
+    if ($user_id < 1) {
         $_SESSION['failed_login'] = Req::val('user_name');
         if($user_id === -2) {
             Flyspray::show_error(L('usernotexist'));


### PR DESCRIPTION
Changes:
* config parameter to set authentication method
* configurable LDAP authentication
* account provisionning from LDAP on first login
* fallback to native authentication if LDAP user not found

To configure LDAP authentication, set following parameters in config file
(flyspray.conf.php):

```
[general]
auth_method = 'ldap'

[ldap]
host = 'ldap.example.com'
port = '389'
version = '3'
base_dn = 'ou=users,dc=example,dc=com'
search_user = 'your_bind_dn'
search_pass = 'your_bind_password'
filter = 'uid=%USERNAME%'
field_name = 'cn'
field_email = 'mail'
```