### PR TITLE
fix overflowing projectselector not clickable

### DIFF
--- a/themes/CleanFS/templates/header.tpl
+++ b/themes/CleanFS/templates/header.tpl
@@ -105,7 +105,6 @@ if(is_readable(BASEDIR.'/themes/'.$this->_theme.'tags.css')): ?>
 	<?php endif;?>
 
 <div id="content">
-	<div class="clear"></div>
 	<?php $show_message = explode(' ', $fs->prefs['pages_welcome_msg']);
 	if ($fs->prefs['intro_message'] && ($proj->id == 0 || $proj->prefs['disp_intro']) && (in_array($do, $show_message)) ):?>
 	<div id="intromessage"><?php echo TextFormatter::render($fs->prefs['intro_message'], 'msg', $proj->id); ?></div>

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -239,7 +239,7 @@ body {background: #f9f9f9; /* direction:rtl;*/}
 a {color: #336699;}
 a:hover {color: #6699cc;}
 #container { min-width: 1000px; position: relative; text-align: left; }
-#content { padding: 10px 20px 10px 20px; min-width: 660px; }
+#content { padding: 0 20px 10px 20px; margin-top:10px min-width: 660px; clear:both; }
 #footer {
   display: block;
   margin: 0px 20px 20px 20px;


### PR DESCRIPTION
When on smaller screens the horizontal project menu, project selector and quicktaskidsearch do not fit on one line, the project selector overflows in Flyspray 1.0 CleanFS theme. Due the css float cleared too late, the content div overlapped and the project selector was not clickable with mouse.