### PR TITLE
use dokuwiki $conf until full rendered

### DIFF
--- a/plugins/dokuwiki/dokuwiki_formattext.inc.php
+++ b/plugins/dokuwiki/dokuwiki_formattext.inc.php
@@ -53,8 +53,7 @@ class dokuwiki_TextFormatter
         $Renderer->entities = getEntities();
         $Renderer->acronyms = getAcronyms();
         $Renderer->interwiki = getInterwiki();
-
-        $conf = $fs_conf;
+        
         $conf['cachedir'] = FS_CACHE_DIR; // for dokuwiki
         $conf['fperm'] = 0600;
         $conf['dperm'] = 0700;
@@ -66,7 +65,8 @@ class dokuwiki_TextFormatter
         }
 
         $return = $Renderer->doc;
-
+        $conf = $fs_conf;
+		
         // Display the output
         if (Get::val('histring')) {
             $words = explode(' ', Get::val('histring'));


### PR DESCRIPTION
before switching back to flyspray global $conf
some dokuwiki $conf custom settings are required when compiling html output, like their relnofollow setting.
(workaround)