### PR TITLE
limit preload task description on long tasklists (default theme)

### DIFF
--- a/themes/CleanFS/templates/index.tpl
+++ b/themes/CleanFS/templates/index.tpl
@@ -364,27 +364,42 @@ echo tpl_select(
 </tr>
 </thead>
 <tbody>
-<?php foreach ($tasks as $task):?>
+<?php
+# to limit preloading detailed_desc in tasklist table in favor of smaller page size and time spend by TextFormatter::render()
+$maxrender=25;
+$taskcount=0;
+foreach ($tasks as $task): ?>
 <tr id="task<?php echo $task['task_id']; ?>" class="severity<?php echo $task['task_severity'];  echo $task['is_closed'] ==1 ? ' closed': '';?>">
 	<td class="caret"></td>
 	<?php if (!$user->isAnon() && $proj->id !=0): ?>
 	<td class="ttcolumn"><input class="ticktask" type="checkbox" name="ids[]" onclick="BulkEditCheck()" value="<?php echo $task['task_id']; ?>"/></td>
 	<?php
 	endif;
+	$taskcount++;
 	foreach ($visible as $col):
 		if($col == 'progress'):?>
 	<td class="task_progress"><div class="progress_bar_container"><span><?php echo $task['percent_complete']; ?>%</span><div class="progress_bar" style="width:<?php echo $task['percent_complete']; ?>%"></div></div></td>
 		<?php elseif ($col == 'summary'):
-			echo tpl_draw_cell($task, $col, "<td class='%s' onmouseover=\"Show(this," . $task['task_id'] . ")\" onmouseout=\"Hide(this, " . $task['task_id'] . ")\">%s</td>");
+			$sumtpl='<td class="%s"';
+			if ($taskcount <= $maxrender) {
+				# TODO: get rid of that inline javascript to make more strict content-security-policy possible.
+				# Maybe replace by event listener that takes care of first $maxrender items?
+				$sumtpl.=' onmouseover="Show(this, '.$task['task_id'].')" onmouseout="Hide(this, '.$task['task_id'].')"';
+			}
+			$sumtpl.='>%s</td>';
+			echo tpl_draw_cell($task, $col, $sumtpl);
 		else:
-		echo tpl_draw_cell($task, $col);
+			echo tpl_draw_cell($task, $col);
 		endif;
 	endforeach;
-	?>
+	if ($taskcount <= $maxrender): ?>
 	<td id="desc_<?php echo $task['task_id']; ?>" class="descbox box">
 	<b><?php echo L('taskdescription'); ?></b>
 	<?php echo $task['detailed_desc'] ? TextFormatter::render($task['detailed_desc'], 'task', $task['task_id'], $task['desccache']) : '<p>'.L('notaskdescription').'</p>'; ?>
 	</td>
+	<?php else: ?>
+	<td></td>
+	<?php endif;?>
 </tr>
 <?php endforeach; ?>
 </tbody>


### PR DESCRIPTION
The default CleanFS theme loads also the task description of each task in a tasklist and only a mouse hover a task summary shows the description preview of a task. This feature has impact on required php workload and those descriptions are not used in most cases and also effects page size for each tasklist view. As compromise this change loads only the task description for maximal first 25 rows of a tasklist.