### PR TITLE
Fix FS#2628, access array offset on value of type int

### DIFF
--- a/includes/class.flyspray.php
+++ b/includes/class.flyspray.php
@@ -86,10 +86,6 @@ class Flyspray
 
         $sizes = array();
         foreach (array(ini_get('memory_limit'), ini_get('post_max_size'), ini_get('upload_max_filesize')) as $val) {
-        	if($val === '-1'){
-				// unlimited value in php configuration
-				$val = PHP_INT_MAX;
-			}
             if (!$val || $val < 0) {
                 continue;
             }


### PR DESCRIPTION
Fix FS#2628 - class.flyspray.php __construct(): Trying to access array offset on value of type int, PHP 7.4
for memory_limit = -1
The check "$val < 0" will skip negav´tive values also. If no meory_limt set, then one of the others will limit the size. Not need extra PHP_INT_MAX.