### PR TITLE
Add sensible default for conf.php in .htaccess template

### DIFF
--- a/htaccess.dist
+++ b/htaccess.dist
@@ -55,6 +55,13 @@ php_flag always_populate_raw_post_data Off
 	deny from all
 </Files>
 
+# hide default location of the config
+<Files ~ "^flyspray.conf.php$">
+	Order allow,deny
+	Deny from all
+</Files>
+
+
 # Some hostings have autocorrection of minor misspelled URLs enabled.
 # We do not want that for Flyspray as it could lead to subtile unwanted behavior.
 <IfModule mod_speling.c>


### PR DESCRIPTION
As far as i can tell, `/setup/index.php` creates the `flyspray.conf.php` in the root directory.

It is likely that new users will not modify the code to store `flyspray.conf.php` in an inherently secure location - out of the web root. That's why i think, that it is a good idea to provide the `.htaccess` which restricts access to the `conf.php`.