### PR TITLE
WIP Add cli options to setup/index

### DIFF
--- a/setup/index.php
+++ b/setup/index.php
@@ -16,6 +16,27 @@ define('APPLICATION_PATH', dirname(BASEDIR));
 define('OBJECTS_PATH', APPLICATION_PATH . '/includes');
 define('TEMPLATE_FOLDER', BASEDIR . '/templates/');
 
+// -----------------------------------------------------------------------------
+// CLI
+// -----------------------------------------------------------------------------
+$shortopts = "";
+
+$longopts = array(
+  "db_type:",         // 'mysql', 'mysqli', or 'pgsql'
+  "db_hostname:",
+  "db_username:",
+  "db_password:",
+  "db_name:",
+  "db_prefix:",
+  "admin_username:",
+  "admin_password:",
+  "admin_email:",
+  "syntaxplugin:",    // 'dokuwiki', 'html', or 'none'
+  "reminder_daemon:", // '1', or '0'
+);
+$cli_options = getopt($shortopts,$longopts);
+
+
 require_once OBJECTS_PATH.'/fix.inc.php';
 require_once OBJECTS_PATH.'/class.gpc.php';
 require_once OBJECTS_PATH.'/class.flyspray.php';
@@ -112,7 +133,7 @@ class Setup extends Flyspray
 
    public $mXmlSchema;
 
-   public function __construct()
+   public function __construct($preset_data=null)
    {
       // Look for ADOdb
       $this->mAdodbPath = dirname(__DIR__) . '/vendor/adodb/adodb-php/adodb.inc.php';
@@ -136,8 +157,17 @@ class Setup extends Flyspray
 		}
 		$this->mAvailableDatabases = array();
 
-		// Process the page actions
-		$this->processActions();
+		if ($preset_data != null) {
+			// Process the page actions
+			$this->processActions();
+		}
+		else {
+			// Process the database checks and install tables
+			if ($this->processDatabaseSetup($preset_data)) {
+				// Proceed to Administration part
+				$this->processAdminConfig($preset_data);
+			}
+		}
 	}
 
    /**
@@ -1227,4 +1257,4 @@ class Setup extends Flyspray
 }
 
 //start the installer, it handles the rest inside the class
-new Setup();
+new Setup($cli_options);


### PR DESCRIPTION
I would like to evolve the setup scripts in a way which allows to run the important setup steps non-interactively. 
This would be nice to have for an automated build system, such as to build a docker container.

My php knowledge is very limited, and i would like to ask for advice, or support.

## Current State
if you run the `setup/index.php` script with the following command:
```bash
php setup/index.php --db_type=pgsql -db_host=db:5432 --db_name=flyspray \ 
  --db_username=flyspray --db_password=flyspray --db_prefix="flyspray_" \
  --admin_username=admin --admin_password=changethis \
  --syntaxplugin=dokuwiki --reminder_daemon='1'
```
you'll currently get a lot of issues regarding the web rendering:
```
PHP Warning:  Attempt to read property "prefs" on null in /home/user/flyspray/includes/i18n.inc.php on line 129

Warning: Attempt to read property "prefs" on null in /home/user/flyspray/includes/i18n.inc.php on line 129
PHP Warning:  Trying to access array offset on value of type null in /home/user/flyspray/includes/i18n.inc.php on line 129

Warning: Trying to access array offset on value of type null in /home/user/flyspray/includes/i18n.inc.php on line 129
PHP Warning:  Cannot modify header information - headers already sent by (output started at /home/user/flyspray/includes/i18n.inc.php:129) in /home/user/flyspray/setup/index.php on line 50

Warning: Cannot modify header information - headers already sent by (output started at /home/user/flyspray/includes/i18n.inc.php:129) in /home/user/flyspray/setup/index.php on line 50
PHP Warning:  Cannot modify header information - headers already sent by (output started at /home/user/flyspray/includes/i18n.inc.php:129) in /home/user/flyspray/setup/index.php on line 51
```

Would you have ideas how to proceed? I haven't found an elegant way to switch of the interactive stuff on demand.