### PR TITLE
remove unused pass_phrase variable

### DIFF
--- a/setup/index.php
+++ b/setup/index.php
@@ -294,7 +294,6 @@ class Setup extends Flyspray
                                 'product_name' => $this->mProductName,
                                 'message' => $this->getPageMessage(),
                                 'admin_email' => $this->getParamValue($data, 'admin_email', ''),
-                                'pass_phrase' => $this->getParamValue($data, 'pass_phrase', ''),
                                 'admin_username' => $this->getParamValue($data, 'admin_username', ''),
 				'admin_realname' => $this->getParamValue($data, 'admin_realname', ''),
 				'admin_xmpp' => $this->getParamValue($data, 'admin_xmpp', ''),


### PR DESCRIPTION
The check in `setup/index.php` contains a variable `pass_phrase` which is no where else used.

Hence this suggestion to remove.