### PR TITLE
Allows sorting tasks by effort / estimated effort

### DIFF
--- a/includes/class.backend.php
+++ b/includes/class.backend.php
@@ -1712,6 +1712,8 @@ LEFT JOIN {cache} cache ON t.task_id=cache.topic AND cache.type=\'task\' ';
             'comments' => 'num_comments',
             'private' => 'mark_private',
             'supertask' => 't.supertask_id',
+	    'effort' => 'effort',
+            'estimatedeffort' => 'estimated_effort'
         );
 
         // make sure that only columns can be sorted that are visible (and task severity, since it is always loaded)


### PR DESCRIPTION
Sorting task list by effort or estimated effort does not work in version 1.0-rc10, because the effort-related fields are not listed as possible ORDER BY keys for the request. The list falls back to default order when one tries to uses these columns for sorting.

This pull request simply adds these two fields to make sorting work as intended.