### PR TITLE
(Fix) set cache directory to prevent warnings

### DIFF
--- a/includes/class.backend.php
+++ b/includes/class.backend.php
@@ -311,6 +311,7 @@ abstract class Backend
 
 	if ($conf['general']['syntax_plugin'] != 'dokuwiki') {
 		$purifierconfig = HTMLPurifier_Config::createDefault();
+    $purifierconfig->set('Cache.SerializerPath', 'cache');
 		$purifierconfig->set('CSS.AllowedProperties', array());
 		if ($fs->prefs['relnofollow']) {
 			$purifierconfig->set('HTML.Nofollow', true);
@@ -1087,6 +1088,7 @@ abstract class Backend
 	# dokuwiki syntax plugin filters on output
 	if ($conf['general']['syntax_plugin'] != 'dokuwiki' && isset($sql_args['detailed_desc'])) {
 		$purifierconfig = HTMLPurifier_Config::createDefault();
+    $purifierconfig->set('Cache.SerializerPath', 'cache');
 		$purifierconfig->set('CSS.AllowedProperties', array());
 		if ($fs->prefs['relnofollow']) {
 			$purifierconfig->set('HTML.Nofollow', true);

--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -421,6 +421,7 @@ switch ($action = Req::val('action'))
 	# dokuwiki syntax plugin filters on output
 	if ($conf['general']['syntax_plugin'] != 'dokuwiki') {
 		$purifierconfig = HTMLPurifier_Config::createDefault();
+    $purifierconfig->set('Cache.SerializerPath', 'cache');
 		$purifierconfig->set('CSS.AllowedProperties', array());
 		if ($fs->prefs['relnofollow']) {
 			$purifierconfig->set('HTML.Nofollow', true);
@@ -2499,6 +2500,7 @@ switch ($action = Req::val('action'))
 		# dokuwiki syntax plugin filters on output
 		if ($conf['general']['syntax_plugin'] != 'dokuwiki') {
 			$purifierconfig = HTMLPurifier_Config::createDefault();
+      $purifierconfig->set('Cache.SerializerPath', 'cache');
 			$purifierconfig->set('CSS.AllowedProperties', array());
 			if ($fs->prefs['relnofollow']) {
 				$purifierconfig->set('HTML.Nofollow', true);


### PR DESCRIPTION
When the "SerializerPath" is not set, it will write into the "vendor" folder. This is critcal and not allowed on all servers. Why not use the existing "cache" folder?