### PR TITLE
load dokuwiki config earlier before writing a cache entry to db, fixes warning GH#817

### DIFF
--- a/plugins/dokuwiki/dokuwiki_formattext.inc.php
+++ b/plugins/dokuwiki/dokuwiki_formattext.inc.php
@@ -23,6 +23,14 @@ class dokuwiki_TextFormatter
 		// Create a renderer
 		$Renderer = new Doku_Renderer_XHTML();
 
+		$conf = $fs_conf;
+		$conf['relnofollow']= $fs->prefs['relnofollow']; # ugly workaround
+		$conf['cachedir'] = FS_CACHE_DIR; # for dokuwiki
+		$conf['fperm'] = 0600;
+		$conf['dperm'] = 0700;
+
+		include_once BASEDIR . '/plugins/dokuwiki/conf/local.php';
+
 		if (!is_string($instructions) || strlen($instructions) < 1) {
 			$modes = p_get_parsermodes();
 			$Parser = new Doku_Parser();
@@ -57,14 +65,6 @@ class dokuwiki_TextFormatter
 		$Renderer->acronyms = getAcronyms();
 		$Renderer->interwiki = getInterwiki();
 
-		$conf = $fs_conf;
-		$conf['relnofollow']= $fs->prefs['relnofollow']; # ugly workaround
-		$conf['cachedir'] = FS_CACHE_DIR; # for dokuwiki
-		$conf['fperm'] = 0600;
-		$conf['dperm'] = 0700;
-
-		include_once BASEDIR . '/plugins/dokuwiki/conf/local.php';
-		
 		// Loop through the instructions
 		foreach ($instructions as $instruction) {
 			// Execute the callback against the Renderer


### PR DESCRIPTION
When a dokuwiki syntax text is not yet cached in the DB, it parses the text.

The config for dokuwiki syntax was not loaded yet there resulting in a warning in php 8.