### PR TITLE
optional autofallback language settings

### DIFF
--- a/includes/class.notify.php
+++ b/includes/class.notify.php
@@ -34,9 +34,9 @@ class Notifications
 
 		if (isset($to[0])) {
 			foreach ($to[0] as $recipient) {
-				if (!empty($recipient['lang'])) {
+				if (!empty($recipient['lang']) && $recipient['lang'] != 'project') {
 					$lang = $recipient['lang'];
-				} else if (!empty($proj_lang)) {
+				} else if (!empty($proj_lang) && $proj_lang !='global') {
 					$lang = $proj_lang;
 				} else {
 					$lang = $fs->prefs['lang_code'];

--- a/includes/i18n.inc.php
+++ b/includes/i18n.inc.php
@@ -125,10 +125,14 @@ function load_translations(){
 		}
 	}
 
-	if(!isset($lang_code) || $lang_code=='' || $lang_code=='project'){
-		if(is_object($proj) && $proj->prefs['lang_code']){
-			$lang_code = $proj->prefs['lang_code'];
-		}else{
+	if (!isset($lang_code) || $lang_code=='' || $lang_code=='project') {
+		if (is_object($proj) && $proj->prefs['lang_code']) {
+			if ($proj->prefs['lang_code'] === 'global') {
+				$lang_code = $fs->prefs['lang_code'];
+			} else {
+				$lang_code = $proj->prefs['lang_code'];
+			}
+		} else {
 			$lang_code = 'en';
 		}
 	}
@@ -142,7 +146,7 @@ function load_translations(){
 	if ($lang_code != 'en' && is_readable($translation)) {
 		include_once $translation;
 		$language = is_array($translation) ? array_merge($language, $translation) : $language;
-                FlySprayI18N::init($lang_code, $language);
+		FlySprayI18N::init($lang_code, $language);
 	} elseif ( 'en'!=substr($lang_code, 0, strpos($lang_code, '_')) && is_readable(BASEDIR.'/lang/'.(substr($lang_code, 0, strpos($lang_code, '_'))).'.php') ){
 		# fallback 'de_AT' to 'de', but not for 'en_US'
 		$translation=BASEDIR.'/lang/'.(substr($lang_code, 0, strpos($lang_code, '_'))).'.php';

--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -1766,7 +1766,7 @@ switch ($action = Req::val('action'))
                  * 'global' means user prefers Flyspray's global language setting.
                  * 'project' use per project setting if set instead of user a language setting with fallback to global.
                  */
-                if (!preg_match('/^(global|project|browser|[a-z]{2,3}(_[a-z]{2,3})?)$/', Post::val('lang_code', 'en'))) {
+                if (!preg_match('/^(project|[a-z]{2,3}(_[a-z]{2,3})?)$/', Post::val('lang_code', 'en'))) {
                         Flyspray::show_error(L('invalidlanguagecode'));
                         break;
                 }

--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -1762,6 +1762,15 @@ switch ($action = Req::val('action'))
                     break;
                 }
 
+                /**
+                 * 'global' means user prefers Flyspray's global language setting.
+                 * 'project' use per project setting if set instead of user a language setting with fallback to global.
+                 */
+                if (!preg_match('/^(global|project|browser|[a-z]{2,3}(_[a-z]{2,3})?)$/', Post::val('lang_code', 'en'))) {
+                        Flyspray::show_error(L('invalidlanguagecode'));
+                        break;
+                }
+
                 # current CleanFS template skips oldpass input requirement for admin accounts: if someone is able to catch an admin session he could simply create another admin acc for example.
                 #if ( (!$user->perms('is_admin') || $user->id == Post::val('user_id')) && !Post::val('oldpass')
                 if ( !$user->perms('is_admin') && !Post::val('oldpass') && (Post::val('changepass') || Post::val('confirmpass')) ) {

--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -1763,8 +1763,7 @@ switch ($action = Req::val('action'))
                 }
 
                 /**
-                 * 'global' means user prefers Flyspray's global language setting.
-                 * 'project' use per project setting if set instead of user a language setting with fallback to global.
+                 * 'project': User prefers using 'project language setting' instead of 'user language setting'. Project language itself has fallback to 'global language setting'.
                  */
                 if (!preg_match('/^(project|[a-z]{2,3}(_[a-z]{2,3})?)$/', Post::val('lang_code', 'en'))) {
                         Flyspray::show_error(L('invalidlanguagecode'));

--- a/themes/CleanFS/templates/common.profile.tpl
+++ b/themes/CleanFS/templates/common.profile.tpl
@@ -79,10 +79,7 @@
       <li>
             <label for="langcode"><?= eL('language') ?></label>
             <select id="langcode" name="lang_code">
-                <?php 
-                #echo tpl_options(array_merge(array('browser', 'project'), Flyspray::listLangs()), Req::val('lang_code', $theuser->infos['lang_code']), true);
-                echo tpl_options( Flyspray::listLangs(), Req::val('lang_code', $theuser->infos['lang_code']), true);
-                ?>
+            <?= tpl_options(array_merge(array('project'), Flyspray::listLangs()), Post::val('lang_code', $theuser->infos['lang_code']), true); ?>
             </select>
         </li>
       <li>

--- a/themes/CleanFS/templates/pm.prefs.tpl
+++ b/themes/CleanFS/templates/pm.prefs.tpl
@@ -23,7 +23,7 @@
 		<li>
 		<label for="langcode"><?= eL('language') ?></label>
 			<select id="langcode" name="lang_code">
-			<?php echo tpl_options(Flyspray::listLangs(), Post::val('lang_code', $proj->prefs['lang_code']), true); ?>
+			<?php echo tpl_options(array_merge(array('global'), Flyspray::listLangs()), Post::val('lang_code', $proj->prefs['lang_code']), true); ?>
 			</select>
 		</li>     
 		<?php echo tpl_checkbox('disp_intro', Post::val('disp_intro', $proj->prefs['disp_intro']), 'disp_intro'); ?>


### PR DESCRIPTION
allows user sets their language to 'project', meaning using the language setting of the project instead of fixed own defined one.

Projects can set their own language, but now also allows setting to 'global', which means the global Flyspray language setting is used.