### PR TITLE
keep protocol visible in emails

### DIFF
--- a/includes/class.notify.php
+++ b/includes/class.notify.php
@@ -423,7 +423,7 @@ class Notifications
 		}
 
 		// Make plaintext URLs into hyperlinks, but don't disturb existing ones!
-		$htmlbody = preg_replace("/(?<!\")(https?:\/\/)([a-z0-9\-.]+\.[a-z\-]+(:[0-9]+)?([\/]([a-z0-9_\/\-.?&%=+#])*)*)/i", '<a href="$1$2">$2</a>', $body);
+		$htmlbody = preg_replace("/(?<![\"\'])(https?:\/\/)([a-z0-9\-.]+\.[a-z\-]+(:[0-9]+)?([\/]([a-z0-9_\/\-.?&%=+#])*)*)/i", '<a href="$1$2">$1$2</a>', $body);
 		$htmlbody = str_replace("\n","<br>", $htmlbody);
 
 		// Those constants used were introduced in 5.4.


### PR DESCRIPTION
- keep http:// or https:// in detected links visible for html body of notification emails

- also ignore replacing links when a single quotation mark before the link is detected, not only double quotation mark, assuming it is part of an html tag attribute.
(https://www.w3.org/TR/html401/intro/sgmltut.html#h-3.2.2 or https://html.spec.whatwg.org/#attributes-2)
