### PR TITLE
show warning if max_input_vars is too low for big category trees

### DIFF
--- a/themes/CleanFS/templates/common.cat.tpl
+++ b/themes/CleanFS/templates/common.cat.tpl
@@ -46,6 +46,14 @@ $categories = $proj->listCategories($proj->id, false, false, false);
 if ( count($categories) ){
   $root = $categories[0];
   unset($categories[0]);
+
+  if ((count($categories)*6 + 4) > ini_get('max_input_vars')) {
+?>
+<div class="error">A category tree update of this size requires sending more than <strong><?= ini_get('max_input_vars') ?></strong> key-value pairs (PHP ini setting <i>max_input_vars</i>).
+But the current size for an update requires up to <?= (count($categories)*6 + 4) ?> key-value pairs.
+Increase <strong>max_input_vars</strong> PHP ini setting before doing any update of this category tree! Otherwise you maybe get a messed up category tree in the database!</div>
+<?php   
+  }
 } else{
   $root=array();
 }


### PR DESCRIPTION
The way categories are managed in Flyspray might hit the max_input_vars PHP ini setting for big category trees. For a default 1000 max_input_vars in PHP ini settings the limit of categories in worst case is 166 categories in a project or the global cat tree. (up to 6 vars  per category entry) 

Without any delete category option selected the default category limit per project is 199 (5*199+4=999) for the default 1000 max_input_vars limit.

This shows a warning if this limit is reached and suggest increasing max_input_vars in PHP in this case.