### PR TITLE
Mail address cleanup

### DIFF
--- a/includes/class.gpc.php
+++ b/includes/class.gpc.php
@@ -147,7 +147,7 @@ abstract class Cookie
  *
  * This is a simple class for safe input validation
  * no mixed stuff here, functions returns always the same type.
- * @author Cristian Rodriguez R <judas.iscariote@flyspray.org>
+ * @author Cristian Rodriguez R
  * @license BSD
  * @notes this intented to be used by Flyspray internals functions/methods
  * please DO NOT use this in templates , if the code processing the input there 

--- a/lang/es.php
+++ b/lang/es.php
@@ -1,9 +1,7 @@
 <?php
 
 /**
-* Esta tradución es actualmente mantenida por
-*  Cristian Rodriguez.
-* Envia un mail con tus correcciones a judas.iscariote@flyspray.org
+* Esta tradución es actualmente mantenida por Cristian Rodriguez.
 *
 * Asegurate de usar un editor que guarde y lea este archivo en utf-8 asi
 * como que utilize finales de linea UNIX..ahh.. y NO USES entidades html ¡¡

--- a/setup/index.php
+++ b/setup/index.php
@@ -3,7 +3,7 @@
 // | Installer - there is still a lot to clean up, but it works
 // +----------------------------------------------------------------------
 // | Copyright (C) 2005 by Jeffery Fernandez <developer@jefferyfernandez.id.au>
-// | Copyright (C) 2006-2007  by Cristian Rodriguez <judas.iscariote@flyspray.org> and Florian Schmitz <floele@gmail.com>
+// | Copyright (C) 2006-2007 by Cristian Rodriguez and Florian Schmitz <floele@gmail.com>
 // +----------------------------------------------------------------------
 
 @set_time_limit(0);

--- a/setup/upgrade.php
+++ b/setup/upgrade.php
@@ -2,8 +2,8 @@
 // +----------------------------------------------------------------------
 // | PHP Source
 // +----------------------------------------------------------------------
-// | Copyright (C) 2006  by Cristian Rodriguez R <judas.iscariote@flyspray.org>
-// | Copyright (C) 2007  by Florian  Florian Schmitz <floele@flyspray.org>
+// | Copyright (C) 2006  by Cristian Rodriguez R
+// | Copyright (C) 2007  by Florian Schmitz
 // +----------------------------------------------------------------------
 // |
 // | Copyright: See COPYING file that comes with this distribution


### PR DESCRIPTION
Some former developer had personal mail addresses for flyspray.org-domain on old hosting.

Not setup on new hosting.