### PR TITLE
preinstall check if ctype extension is enabled

### DIFF
--- a/setup/templates/pre_install.tpl
+++ b/setup/templates/pre_install.tpl
@@ -16,10 +16,17 @@
 		<td align="left"><b><?php echo $php_output; ?></b></td>
 		<td>&nbsp;</td>
 	</tr>
+	
 	<tr>
 		<td>XML Extension</td>
 		<td align="left"><b><?php echo Setup::ReturnStatus($xmlStatus); ?></b></td>
-		<td></td>
+		<td>&nbsp;</td>
+	</tr>
+	<tr>
+		<?php /* Some minimal distros like 'Alpine Linux' have not the ctype extension installed/enabled by default */ ?>
+		<td>ctype Extension</td>
+		<td align="left"><b><?php echo Setup::ReturnStatus(extension_loaded('ctype'), 'yes'); ?></b></td>
+		<td>&nbsp;</td>
 	</tr>
 	<tr>
 		<td>mbstring Extension</td>


### PR DESCRIPTION
Some minimal linux distros do not install/enable the ctype extension on php install.

So lets add a check here.