### PR TITLE
remove changed params from tpl_userlinkavatar() call in task history …

### DIFF
--- a/themes/CleanFS/templates/details.tabs.history.callback.tpl
+++ b/themes/CleanFS/templates/details.tabs.history.callback.tpl
@@ -21,7 +21,7 @@
   <tr>
     <td><?php echo Filters::noXSS(formatDate($history['event_date'], false)); ?></td>
     <?php if($fs->prefs['enable_avatars'] == 1) { ?>
-    <td><?php echo tpl_userlinkavatar($history['user_id'], $fs->prefs['max_avatar_size'] / 2, 'left', '0px 5px 0px 0px'); ?> <?php echo tpl_userlink($history['user_id']); ?></td>
+    <td><?php echo tpl_userlinkavatar($history['user_id'], $fs->prefs['max_avatar_size'] / 2); ?> <?php echo tpl_userlink($history['user_id']); ?></td>
     <?php } else { ?>
     <td><?php echo tpl_userlink($history['user_id']); ?></td>
     <?php } ?>


### PR DESCRIPTION
…template

3th and 4th param of tpl_userlinkavatar() changed from 'float' and 'padding' to 'class' and 'style'.

So this call is adapted. 3th and 4th param are optional.

And the CSS for that can be done without explicit setting class or inline style there. For example there can be a '.userlist.history a img' selector used for that.