### PR TITLE
Flyspray/Flyspray #880

### DIFF
--- a/includes/modify.inc.php
+++ b/includes/modify.inc.php
@@ -109,9 +109,22 @@ switch ($action = Req::val('action'))
             if ($user->isAnon()) {
                 Flyspray::redirect(createURL('details', $task_id, null, array('task_token' => $token)));
             } else {
-                Flyspray::redirect(createURL('details', $task_id));
+                if (Post::val('addanother') != 1) {
+                    if (array_key_exists('addanothertask', $_SESSION)) {
+                        unset($_SESSION['addanothertask']);
+                    }
+
+                    Flyspray::redirect(createURL('details', $task_id));
+                } else {
+                    $_SESSION['addanothertask'] = 1;
+                    Flyspray::redirect(createURL('newtask', Post::val('project_id')));
+                }
             }
         } else {
+            if (array_key_exists('addanothertask', $_SESSION)) {
+                unset($_SESSION['addanothertask']);
+            }
+
             Flyspray::show_error(L('databasemodfailed'));
             break;
         }

--- a/scripts/newtask.php
+++ b/scripts/newtask.php
@@ -61,12 +61,24 @@ if ($proj->prefs['use_tags']) {
 		array($proj->id)
 	);
 	$taglist=$db->fetchAllArray($restaglist);
-	
 }
 $page->assign('taglist', $taglist);
 
 $page->assign('userlist', $userlist);
 $page->assign('old_assigned', '');
+
+$addanothertask = 0;
+
+if (!$user->isAnon() && array_key_exists('addanothertask', $_SESSION) && $_SESSION['addanothertask'] == 1) {
+	$addanothertask = 1;
+}
+
+// Clear the "addanothertask" flag here so it can't linger in the session
+if (array_key_exists('addanothertask', $_SESSION)) {
+	unset($_SESSION['addanothertask']);
+}
+
+$page->assign('addanothertask', $addanothertask);
 $page->pushTpl('newtask.tpl');
 
 ?>

--- a/themes/CleanFS/templates/newtask.tpl
+++ b/themes/CleanFS/templates/newtask.tpl
@@ -16,7 +16,7 @@
 			return true;
 		}
 		var detail = document.getElementById("details").value;
-    		var project_id = document.getElementsByName('project_id')[0].value;
+		var project_id = document.getElementsByName('project_id')[0].value;
 
 		var xmlHttp = new XMLHttpRequest();
 		xmlHttp.open("POST", "<?php echo Filters::noXSS($baseurl); ?>js/callbacks/searchtask.php", false);
@@ -168,14 +168,14 @@
           <?php endif; ?>
 
         <?php if($proj->prefs['use_effort_tracking']) {
-        	if ($user->perms('view_effort')) {
+				if ($user->perms('view_effort')) {
         ?>
-        	<li>
+			<li>
                 <label for="estimatedeffort"><?= eL('estimatedeffort') ?></label>
                 <input id="estimated_effort" name="estimated_effort" class="text" type="text" size="5" maxlength="100" value="0" />
                 <?= eL('hours') ?>
-        	</li>
-        	<?php }
+			</li>
+			<?php }
         } ?>
 
           <?php if ($user->perms('manage_project')): ?>
@@ -234,6 +234,13 @@
           &nbsp;&nbsp;<input class="text" type="checkbox" id="notifyme" name="notifyme"
           value="1" checked="checked" />&nbsp;<label class="inline left" for="notifyme"><?= eL('notifyme') ?></label>
           <?php endif; ?>
+
+          <?php if (!$user->isAnon()): ?>
+          <span style="margin-top: 1em;display: block;">
+          &nbsp;&nbsp;<input class="text" type="checkbox" id="addanother" name="addanother"
+          value="1"<?php echo ($addanothertask == 1 ? ' checked="checked"' : ''); ?> />&nbsp;<label class="inline left" for="addanother"><?= eL('addanother') ?></label>
+          </span>
+          <?php endif; ?>
       </p>
 
         <?php if ($user->perms('create_attachments')): ?>
@@ -274,7 +281,6 @@
 
 <button class="button positive" style="display:block;margin-top:20px" accesskey="s" type="submit"><?= eL('addthistask') ?></button>
       </div>
-
     <div class="clear"></div>
   </div>
 </form>


### PR DESCRIPTION
Allow new tasks to be added in sequence by non-anonymous users.

In scripts/newtask.php:

Add a boolean value "addanothertask" to template data.  If the user is logged in and the checkbox was previously checked, this state is carried to the next new task via $_SESSION['addanothertask'].

If present, previously set session flag is cleared.

In themes/CleanFS/templates/newtask.tpl:

Add a checkbox "addanothertask", only visible to logged-in users.

In includes/modify.in.php, case "newtask.newtask":

If the "addanothertask" checkbox was not checked, redirect to task details as before.

Otherwise, set $_SESSION['addanothertask'] = 1 and redirect back to newtask.

On error, clear the session flag to prevent it from lingering.