### PR TITLE
Flyspray/Flyspray #879

### DIFF
--- a/themes/CleanFS/templates/pm.prefs.tpl
+++ b/themes/CleanFS/templates/pm.prefs.tpl
@@ -102,7 +102,7 @@
 			<label for="defaultdueversion"><?php echo Filters::noXSS(L('defaultdueinversion')); ?></label>
 			<select id="defaultdueversion" name="default_due_version">
 			<option value="0"><?= eL('undecided') ?></option>
-			<?php echo tpl_options($proj->listVersions(false, 3), Post::val('default_due_version', $proj->prefs['default_due_version']), true); ?>
+			<?php echo tpl_options($proj->listVersions(false, 3), Post::val('default_due_version', $proj->prefs['default_due_version'])); ?>
 			</select>
 		</li>
 		<li>


### PR DESCRIPTION
In themes/CleanFS/templates/pm.prefs.tpl:

Remove third parameter ($labelIsValue) from tpl_options() on line 105.

This makes the <select> render with version_id as option values.

Version ID is then stored in {projects}.default_due_version, which allows the "Due In Version" <select> in newtask to render as expected.