### PR TITLE
false/true of DEBUG_SQL constant instead just defined()

### DIFF
--- a/includes/class.database.php
+++ b/includes/class.database.php
@@ -130,8 +130,10 @@ class Database
 			$this->dblink->setCharSet('utf8');
 		}
 
-		// enable debug if constant DEBUG_SQL is defined.
-		!defined('DEBUG_SQL') || $this->dblink->debug = true;
+		// enable debug if constant DEBUG_SQL is defined AND true
+		if (defined('DEBUG_SQL') && DEBUG_SQL) {
+			$this->dblink->debug = true;
+		}
             
 		if ($dbtype === 'mysql' || $dbtype === 'mysqli') {
 			$dbinfo = $this->dblink->serverInfo();

--- a/includes/class.database.php
+++ b/includes/class.database.php
@@ -132,9 +132,20 @@ class Database
 
 		// enable debug if constant DEBUG_SQL is defined AND true
 		if (defined('DEBUG_SQL') && DEBUG_SQL) {
-			$this->dblink->debug = true;
+			/**
+   			 * Beside true/false; 3 other non-boolean modes are possible for ADOdb.
+			 * @see https://adodb.org/dokuwiki/doku.php?id=v5:userguide:debug
+			 * -1:like true, suppress line separators
+			 * -99: show only failed statements
+			 * 99: backtrace of every statement
+			 */
+			if (in_array(DEBUG_SQL, [-1, -99, 99])) {
+				$this->dblink->debug = DEBUG_SQL;
+			} else {
+				$this->dblink->debug = true;
+			}
 		}
-            
+
 		if ($dbtype === 'mysql' || $dbtype === 'mysqli') {
 			$dbinfo = $this->dblink->serverInfo();
 			if (isset($dbinfo['version']) && version_compare($dbinfo['version'], '5.0.2', '>=')) {

--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -87,8 +87,17 @@ define('FS_CACHE_DIR', Flyspray::get_tmp_dir() . DIRECTORY_SEPARATOR . FS_DOMAIN
 
 is_dir(FS_CACHE_DIR) || @mkdir(FS_CACHE_DIR, 0700);
 
-// developers or advanced users only
-//define('DEBUG_SQL',true);
+/** 
+ * developers or advanced users only
+ *
+ * Beside setting to true/false, the nonboolean values -1, -99, 99 are allowed too.
+* @see https://adodb.org/dokuwiki/doku.php?id=v5:userguide:debug
+ *
+ * -1: same as true, but <hr> line separation is suppressed (historical output HTML formatting of ADOdb)
+ * 99: with backtrace printed, so means verbose output
+ * -99: only when a sql statement failed
+ */
+//define('DEBUG_SQL', true);
 //define('DEBUG_EXCEPTION', true);
 
 # 201508: Currently without usage! Was once used in file fsjabber.php (not in src anymore), but not within class.jabber2.php.

--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -91,7 +91,7 @@ is_dir(FS_CACHE_DIR) || @mkdir(FS_CACHE_DIR, 0700);
  * developers or advanced users only
  *
  * Beside setting to true/false, the nonboolean values -1, -99, 99 are allowed too.
-* @see https://adodb.org/dokuwiki/doku.php?id=v5:userguide:debug
+ * @see https://adodb.org/dokuwiki/doku.php?id=v5:userguide:debug
  *
  * -1: same as true, but <hr> line separation is suppressed (historical output HTML formatting of ADOdb)
  * 99: with backtrace printed, so means verbose output


### PR DESCRIPTION
Before it was check only if DEBUG_SQL was defined or not to enable debug mode. Now this setting supports different values.

Beside setting true/false allows setting DEBUG_SQL to the special ADOdb values -1, 99, and -99.