### PR TITLE
Flyspray/Flyspray #826: Hide User Avatars On Comments

### DIFF
--- a/themes/CleanFS/templates/details.tabs.comment.tpl
+++ b/themes/CleanFS/templates/details.tabs.comment.tpl
@@ -2,7 +2,9 @@
 <div id="comments" class="tab active">
 <?php foreach($comments as $comment): ?>
 	<div class="comment_container" id="<?php echo 'comment' . $comment['comment_id']; ?>">
+<?php if($fs->prefs['enable_avatars'] == 1): ?>
 		<div class="comment_avatar"><?php echo tpl_userlinkavatar($comment['user_id'], $fs->prefs['max_avatar_size'], 'av_comment'); ?></div>
+<?php endif; ?>
 		<div class="comment">
 			<div class="comment_header">
 				<div class="comment_header_actions">
@@ -50,7 +52,9 @@
 <?php endforeach; ?>
 <?php if ($user->perms('add_comments') && (!$task_details['is_closed'] || $proj->prefs['comment_closed'])): ?>
 	<div class="comment_container">
+<?php if($fs->prefs['enable_avatars'] == 1): ?>
 		<div class="comment_avatar"><?php echo tpl_userlinkavatar($user->id, $fs->prefs['max_avatar_size'], 'av_comment'); ?></div>
+<?php endif; ?>
 		<div class="comment">
 			<div class="comment_header"><?= eL('addcomment') ?></div>
 			<div class="commenttext">

--- a/themes/CleanFS/templates/editcomment.tpl
+++ b/themes/CleanFS/templates/editcomment.tpl
@@ -1,6 +1,8 @@
 <div class="box">
 	<div class="comment_container">
+<?php if($fs->prefs['enable_avatars'] == 1): ?>
 		<div class="comment_avatar"><?php echo tpl_userlinkavatar($user->id, $fs->prefs['max_avatar_size'], 'av_comment'); ?></div>
+<?php endif; ?>
 		<div class="comment">
 			<div class="comment_header">
 				<div class="comment_header_actions">

--- a/themes/CleanFS/theme.css
+++ b/themes/CleanFS/theme.css
@@ -966,7 +966,7 @@ div.comment_container .comment {
 	width: 700px;
 	border-radius: 3px;
 }
-div.comment_container .comment:before {
+div.comment_container > div.comment_avatar + .comment:before {
 	content: ' ';
 	position: absolute;
 	width: 0;
@@ -976,7 +976,7 @@ div.comment_container .comment:before {
 	border: 8px solid;
 	border-color: transparent #e1e1e1 transparent transparent;
 }
-div.comment_container .comment:after {
+div.comment_container > div.comment_avatar + .comment:after {
 	content: ' ';
 	position: absolute;
 	width: 0;


### PR DESCRIPTION
Don't display user avatars on comments if FS->prefs['enable_avatars'] is not enabled.

Adjust comment CSS to only display the avatar "pointer" if the avatar element is present.