### PR TITLE
allow detecting [ and ] as part of URL for externallink parser mode

### DIFF
--- a/plugins/dokuwiki/inc/parser/parser.php
+++ b/plugins/dokuwiki/inc/parser/parser.php
@@ -845,7 +845,7 @@ class Doku_Parser_Mode_externallink extends Doku_Parser_Mode {
     function preConnect() {
 
         $ltrs = '\w';
-        $gunk = '/\#~:.?+=&%@!\-';
+        $gunk = '/\#~:.?+=&%@!\-\[\]';
         $punc = '.:?\-;,';
         $host = $ltrs.$punc;
         $any  = $ltrs.$gunk.$punc;


### PR DESCRIPTION
when dokuwiki syntax is used

fixes #825