### PR TITLE
format of nonexistent tasks

### DIFF
--- a/includes/class.tpl.php
+++ b/includes/class.tpl.php
@@ -186,14 +186,35 @@ function tpl_form($action, $name=null, $method=null, $enctype=null, $attr='')
  */
 function tpl_tasklink($task, $text = null, $strict = false, $attrs = array(), $title = array('status','summary','percent_complete'))
 {
-    global $user;
+	global $user;
 
-    $params = array();
+	$params = array();
 
-    if (!is_array($task) || !isset($task['status_name'])) {
-        $td_id = (is_array($task) && isset($task['task_id'])) ? $task['task_id'] : $task;
-        $task = Flyspray::getTaskDetails($td_id, true);
-    }
+	if (is_string($task) || is_numeric($task)) {
+		$taskid=$task;
+		$task = Flyspray::getTaskDetails($task, true);
+		// task not exist 
+		if ($task === false) {
+			if (is_null($text)) {
+				$text = 'FS#'.$taskid;
+			}
+			return htmlspecialchars($text, ENT_QUOTES, 'utf-8');
+		}
+	} else if (is_array($task)) {
+		if (isset($task['task_id']) && !isset($task['status_name'])) {
+			$taskid=$task['task_id'];
+			$task = Flyspray::getTaskDetails($task['task_id'], true);
+			// task not exist 
+			if ($task === false) {
+				if (is_null($text)) {
+					$text = 'FS#'.$task['task_id'];
+				}
+				return htmlspecialchars($text, ENT_QUOTES, 'utf-8');
+			}
+		}
+	} else {
+		return '';
+	}
 
     if ($strict === true && (!is_object($user) || !$user->can_view_task($task))) {
         return '';


### PR DESCRIPTION
when something looks like a FS#xxx Flyspray task in comments or task descriptions, but does not exists, then catch that and do not try to build a link to nowhere.