### PR TITLE
add audit ignores for some dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,15 @@
             "url": "https://github.com/jamiebicknell/Sparkline"
         }
     ],
+    "config": {
+        "audit": {
+            "ignore": {
+                "PKSA-rfc1-gnmf-7kkz" : "ADOdb: vulnerable sqlite3 driver not used by Flyspray",
+                "PKSA-jm5q-b4t5-4pm4" : "ADOdb: vulnerable function pg_insert_id() in PostgreSQL driver not used by Flyspray",
+                "PKSA-tzjk-yn1s-49ds" : "swiftmailer: not affected"
+            }
+        }
+    },
     "scripts": {
         "post-update-cmd": [
             "rm -rf vendor/dapphp/securimage/captcha.html vendor/dapphp/securimage/example_form.php vendor/dapphp/securimage/example_form.ajax.php vendor/dapphp/securimage/securimage_play.swf vendor/dapphp/securimage/examples/",


### PR DESCRIPTION
composer prevents now installing dependencies for package versions with known security issues.

Ideally we would just use the current fixed versions of that packages, but this is not done yet. (extra migration work)

So temporarly added that ignore section to composer.json, because I think the vulnerable parts of that packages versions are not used or accessible by Flyspray.